### PR TITLE
Only pass instrument loader

### DIFF
--- a/changelog/120.breaking.rst
+++ b/changelog/120.breaking.rst
@@ -1,1 +1,1 @@
-sunxspex.sunxspex_fitting.data_loader.LoadSpec and, by extension, sunxspex.sunxspex_fitting.fitter.SunXspex no longer accepts files and dictionaries, only instances of sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint. 
+sunxspex.sunxspex_fitting.data_loader.LoadSpec and, by extension, sunxspex.sunxspex_fitting.fitter.SunXspex no longer accepts files and dictionaries, only instances of sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint.

--- a/changelog/120.breaking.rst
+++ b/changelog/120.breaking.rst
@@ -1,0 +1,1 @@
+sunxspex.sunxspex_fitting.data_loader.LoadSpec and, by extension, sunxspex.sunxspex_fitting.fitter.SunXspex no longer accepts files and dictionaries, only instances of sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint. 

--- a/sunxspex/sunxspex_fitting/data_loader.py
+++ b/sunxspex/sunxspex_fitting/data_loader.py
@@ -6,8 +6,6 @@ from copy import deepcopy
 
 import numpy as np
 
-from astropy.io import fits
-
 from sunxspex.logging import get_logger
 from sunxspex.sunxspex_fitting import instruments as inst  # sunxspex.sunxspex_fitting.instruments
 from sunxspex.sunxspex_fitting.parameter_handler import (  # sunxspex.sunxspex_fitting.parameter_handler
@@ -30,7 +28,7 @@ class LoadSpec:
     Parameters
     ----------
     *args : `sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint`
-            Instrument loader that contains the instument data and inherits 
+            Instrument loader that contains the instument data and inherits
             from `sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint`.
 
     Properties
@@ -109,13 +107,13 @@ class LoadSpec:
 
         # get ready to load multiple spectra if needed
         self.loaded_spec_data, self.instruments = {}, {}
-        for s,a in enumerate(args):
+        for s, a in enumerate(args):
             if isinstance(a, inst.InstrumentBlueprint):
                 self.loaded_spec_data[f"spectrum{s+1}"] = args[s]
                 self.instruments[f"spectrum{s+1}"] = args[s].__class__.__name__
             else:
                 logger.info(
-                "Please pass instrument loader classes with data that inherit from `sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint`.")
+                    "Please pass instrument loader classes with data that inherit from `sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint`.")
 
         # Adding these classes should also yield {"spectrum1":..., "spectrum2":..., etc.}
 
@@ -305,7 +303,7 @@ class LoadSpec:
 
         # pass the new instrument loader instance to the main fitting class
         s = LoadSpec(nu)
-        
+
         s.rebin = 10
         s.undo_rebin = \'all\' <equivalent to> s.undo_rebin
         """

--- a/sunxspex/sunxspex_fitting/fitter.py
+++ b/sunxspex/sunxspex_fitting/fitter.py
@@ -476,7 +476,7 @@ class SunXspex:
         Bool.
         """
         if isinstance(model_function, (types.FunctionType, types.BuiltinFunctionType)):
-            self._model = deconstruct_lambda(model_function)  # model_function
+            self._model = deconstruct_lambda(self.dynamic_function_source, model_function)  # model_function
         elif type(model_function) is str:
             self._model = self._mod_from_str(model_string=model_function, _create_separate_models_for_one=True)
         else:
@@ -745,7 +745,7 @@ class SunXspex:
         # can only remove if the user added the model, defined models from
         # photon_models_for_fitting.py are protected
         if inspect.getmodule([function_name]).__name__ in (__name__):
-            del self.defined_photon_models[function_name], sefl.funcs[function_name], \
+            del self.defined_photon_models[function_name], self.funcs[function_name], \
                 self.dynamic_function_source[function_name]
             logger.indo(f"Model {function_name} removed.")
         else:
@@ -2162,7 +2162,7 @@ class SunXspex:
                 else:
                     self.correlation_matrix[i, j] = cov / (np.sqrt(self._covariance_matrix[i, i]) * np.sqrt(self._covariance_matrix[j, j]))
         except LinAlgError:
-            warnings.warn(f"LinAlgError when calculating the hessian. Errors may not be calculated.")
+            warnings.warn("LinAlgError when calculating the hessian. Errors may not be calculated.")
         return self.sigmas
 
     def _calc_hessian(self, mod_without_x, fparams, step=0.01, _abs_step=None):

--- a/sunxspex/sunxspex_fitting/fitter.py
+++ b/sunxspex/sunxspex_fitting/fitter.py
@@ -66,7 +66,7 @@ class SunXspex:
     Parameters
     ----------
     *args : `sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint`
-            Instrument loader that contains the instument data and inherits 
+            Instrument loader that contains the instument data and inherits
             from `sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint`.
 
     Properties

--- a/sunxspex/sunxspex_fitting/fitter.py
+++ b/sunxspex/sunxspex_fitting/fitter.py
@@ -65,35 +65,9 @@ class SunXspex:
 
     Parameters
     ----------
-    *args : dict
-            Dictionaries for custom data to be passed to `sunxspex.sunxspex_fitting.instruments.CustomLoader`.
-            These will be added before any instrument file entries from `pha_file`.
-
-    pha_file : string or list of strings
-            The PHA file or list of PHA files for the spectrum to be loaded.
-            See LoadSpec class.
-
-    arf_file, rmf_file : string or list of strings
-            The ARF and RMF files associated with the PHA file(s). If none are given it is assumed
-            that these are in the same directory with same filename as the PHA file(s) but with
-            extensions '.arf' and '.rmf', respectively.
-            See LoadSpec class.
-
-    srm_file : string
-            The file that contains the spectral response matrix for the given spectrum.
-            See LoadSpec class.
-
-    srm_custom : 2d array
-            User defined spectral response matrix. This is accepted over the SRM created from any
-            ARF and RMF files given.
-            See LoadSpec class.
-
-    custom_channel_bins, custom_photon_bins : 2d array
-            User defined channel bins for the columns and rows of the SRM matrix.
-            E.g., custom_channel_bins=[[1,1.5],[1.5,2],...]
-            See LoadSpec class.
-
-    **kwargs : Passed to LoadSpec.
+    *args : `sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint`
+            Instrument loader that contains the instument data and inherits 
+            from `sunxspex.sunxspex_fitting.instruments.InstrumentBlueprint`.
 
     Properties
     ----------
@@ -398,10 +372,9 @@ class SunXspex:
         self.dynamic_function_source = {}
         self.dynamic_vars = {}
         self.defined_photon_models = {**defined_photon_models}
-        self.data = LoadSpec(*args, pha_file=pha_file, arf_file=arf_file, rmf_file=rmf_file, srm_file=srm_file, srm_custom=srm_custom,
-                             custom_channel_bins=custom_channel_bins, custom_photon_bins=custom_photon_bins, **kwargs)
+        self.data = LoadSpec(*args)
 
-        self._construction_string_sunxspex = f"SunXspex({args},pha_file={pha_file},arf_file={arf_file},rmf_file={rmf_file},srm_file={srm_file},srm_custom={srm_custom},custom_channel_bins={custom_channel_bins},custom_photon_bins={custom_photon_bins},**{kwargs})"
+        self._construction_string_sunxspex = f"SunXspex({args})"
 
         self.loglikelihood = "cstat"
 

--- a/sunxspex/sunxspex_fitting/fitter.py
+++ b/sunxspex/sunxspex_fitting/fitter.py
@@ -366,7 +366,7 @@ class SunXspex:
     s_minimised_params = s.fit()
     """
 
-    def __init__(self, *args, pha_file=None, arf_file=None, rmf_file=None, srm_file=None, srm_custom=None, custom_channel_bins=None, custom_photon_bins=None, **kwargs):
+    def __init__(self, *args):
         """Construct the class and set up some defaults."""
         self.funcs = {}
         self.dynamic_function_source = {}

--- a/sunxspex/sunxspex_fitting/tests/test_fitter.py
+++ b/sunxspex/sunxspex_fitting/tests/test_fitter.py
@@ -51,7 +51,7 @@ def custom_spec():
 
     noise_constant = np.mean(noise)
 
-    custom_spec = SunXspex(custom_dict)
+    custom_spec = SunXspex(CustomLoader(custom_dict))
 
     # add the model to be used in fitting
     custom_spec.add_photon_model(gauss)


### PR DESCRIPTION
Separate more of the instrument specific code from the more general fitting code. Remove the ability to pass files and dictionaries directly to the fitter. instead, the files (or dictionaries) can be passed to instrument specific (or custom) loaders and then passed to the fitting code.

This is to address #119 in order to support a more modular approach to the code and reduce complexity (also pointed out in #107).