### PR TITLE
fix fitter / instrument class to allow parallelization

### DIFF
--- a/sunxspex/sunxspex_fitting/instruments.py
+++ b/sunxspex/sunxspex_fitting/instruments.py
@@ -201,6 +201,9 @@ class InstrumentBlueprint:
         """String representation of `_loaded_spec_data`."""
         return str(self._loaded_spec_data)
 
+    def items(self):
+        return self._loaded_spec_data.items()
+
 
 # Instrument specific data loaders
 #    As long as these loaders get the spectral data to fit into the correct dictionary form and assigned to self._loaded_spec_data then


### PR DESCRIPTION
- Fix `__setstate__` and `__getstate__` associated with `pickle`ing for parallelizing e.g. MCMC properly.
- Also change the `function_creator` and `deconstruct_lambda` functions to remove the "dynamic source" side effect.
IMO that shouldn't be part of the function body and should just be done outside of the function call.
If we want that to be part of the call, it should be a member function (method) and not a free function.