### PR TITLE
remove old circleci webhook config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,3 @@ workflows:
   test-documentation:
     jobs:
       - html-docs
-
-notify:
-  webhooks:
-    - url: https://giles.cadair.dev/circleci


### PR DESCRIPTION
I have setup the new style webhooks through the UI, but you aren't using them at the moment so :shrug: 