### PR TITLE
Add albedo correction

### DIFF
--- a/changelog/161.feature.rst
+++ b/changelog/161.feature.rst
@@ -1,0 +1,1 @@
+Add function `~sunkit_spex.models.physical.albedo.get_albedo_matrix` to calculate Albedo correction for given input spectrum and add model `~sunkit_spex.models.physical.albedo.Albedo` to correct modeled photon spectrum for albedo.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx_automodapi.smart_resolver",
     "sphinx_changelog",
     "sphinx_gallery.gen_gallery",
+    "matplotlib.sphinxext.plot_directive"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ will help you know where to look for certain things:
 * :doc:`Topic guides </discussion/index>` discuss key topics and concepts at a
   fairly high level and provide useful background information and explanation.
 
-* :doc:`Reference guides </reference/index>` contain technical reference for APIs and
+* :doc:`Reference </reference/index>` contain technical reference for APIs and
   other aspects of sunkit-spex machinery. They describe how it works and how to
   use it but assume that you have a basic understanding of key concepts.
 

--- a/docs/reference/fitting.rst
+++ b/docs/reference/fitting.rst
@@ -1,0 +1,10 @@
+Fitting (`sunkit_spex.fitting`)
+*******************************
+
+``sunkit_spex.fitting`` contains the sunkit-spex fitting infrastructure including statistics, optimisers and fitters.
+
+
+.. automodapi:: sunkit_spex.fitting.objective_functions
+.. automodapi:: sunkit_spex.fitting.optimizer_tools
+.. automodapi:: sunkit_spex.fitting.statistics
+.. automodapi:: sunkit_spex.fitting

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -4,10 +4,12 @@ Reference
 
 Software and API.
 
+.. automodapi:: sunkit_spex
 
 .. toctree::
    :maxdepth: 2
 
-   fitting/index
-   models/index
-   legacy/index
+
+   fitting
+   models
+   legacy

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -4,13 +4,10 @@ Reference
 
 Software and API.
 
-.. automodapi:: sunkit_spex
-.. automodapi:: sunkit_spex.legacy.thermal
-.. automodapi:: sunkit_spex.legacy.integrate
-.. automodapi:: sunkit_spex.legacy.io
-.. automodapi:: sunkit_spex.legacy.emission
-.. automodapi:: sunkit_spex.legacy.constants
-.. automodapi:: sunkit_spex.legacy.fitting
-.. automodapi:: sunkit_spex.legacy.fitting.io
-.. automodapi:: sunkit_spex.legacy.photon_power_law
-.. automodapi:: sunkit_spex.extern.rhessi
+
+.. toctree::
+   :maxdepth: 2
+
+   fitting/index
+   models/index
+   legacy/index

--- a/docs/reference/legacy.rst
+++ b/docs/reference/legacy.rst
@@ -1,0 +1,13 @@
+Legacy (`sunkit_spex.legacy`)
+*****************************
+
+
+.. automodapi:: sunkit_spex.legacy
+.. automodapi:: sunkit_spex.legacy.thermal
+.. automodapi:: sunkit_spex.legacy.integrate
+.. automodapi:: sunkit_spex.legacy.io
+.. automodapi:: sunkit_spex.legacy.emission
+.. automodapi:: sunkit_spex.legacy.constants
+.. automodapi:: sunkit_spex.legacy.fitting_legacy
+.. automodapi:: sunkit_spex.legacy.fitting_legacy.io
+.. automodapi:: sunkit_spex.legacy.photon_power_law

--- a/docs/reference/legacy.rst
+++ b/docs/reference/legacy.rst
@@ -1,6 +1,8 @@
 Legacy (`sunkit_spex.legacy`)
 *****************************
 
+.. warning::
+   The legacy module contains legacy code which will no longer be maintained and will be removed in the near future.
 
 .. automodapi:: sunkit_spex.legacy
 .. automodapi:: sunkit_spex.legacy.thermal
@@ -8,6 +10,6 @@ Legacy (`sunkit_spex.legacy`)
 .. automodapi:: sunkit_spex.legacy.io
 .. automodapi:: sunkit_spex.legacy.emission
 .. automodapi:: sunkit_spex.legacy.constants
-.. automodapi:: sunkit_spex.legacy.fitting_legacy
-.. automodapi:: sunkit_spex.legacy.fitting_legacy.io
+.. automodapi:: sunkit_spex.legacy.fitting
+.. automodapi:: sunkit_spex.legacy.fitting.io
 .. automodapi:: sunkit_spex.legacy.photon_power_law

--- a/docs/reference/models.rst
+++ b/docs/reference/models.rst
@@ -1,0 +1,8 @@
+Models (`sunkit_spex.models`)
+*****************************
+
+``sunkit_spex.models`` contains a number of functional and physical models.
+
+
+.. automodapi:: sunkit_spex.models
+.. automodapi:: sunkit_spex.models.physical

--- a/docs/reference/models.rst
+++ b/docs/reference/models.rst
@@ -5,4 +5,8 @@ Models (`sunkit_spex.models`)
 
 
 .. automodapi:: sunkit_spex.models
+.. automodapi:: sunkit_spex.models.models
+.. automodapi:: sunkit_spex.models.instrument_response
 .. automodapi:: sunkit_spex.models.physical
+.. automodapi:: sunkit_spex.models.physical.thermal
+.. automodapi:: sunkit_spex.models.physical.albedo

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,8 @@ norecursedirs =
     .history
     sunkit_spex/extern
 doctest_plus = enabled
+doctest_subpackage_requires =
+    * =  ndcube>2.3.0
 doctest_optionflags =
     NORMALIZE_WHITESPACE
     FLOAT_CMP

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,8 +14,6 @@ norecursedirs =
     .history
     sunkit_spex/extern
 doctest_plus = enabled
-doctest_subpackage_requires =
-    * =  ndcube>2.3.0
 doctest_optionflags =
     NORMALIZE_WHITESPACE
     FLOAT_CMP

--- a/sunkit_spex/legacy/fitting/fitter.py
+++ b/sunkit_spex/legacy/fitting/fitter.py
@@ -2441,7 +2441,7 @@ class Fitter:
                 replacement_steps = np.mean(self._minimize_solution.final_simplex[0][:, zero_steps], axis=0) * step
             except AttributeError:
                 replacement_steps = 0
-            steps[zero_steps] = replacement_steps if replacement_steps > 0 else step
+            steps[zero_steps] = replacement_steps if replacement_steps.size > 0 else step
         else:
             steps = _abs_step
 

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -80,7 +80,9 @@ class Albedo(FittableModel):
         description="Angle between the observer and the source",
         fixed=False,
     )
-    anisotropy = Parameter(name="anisotropy", default=1, description="The anisotropy used for albedo correction", fixed=True)
+    anisotropy = Parameter(
+        name="anisotropy", default=1, description="The anisotropy used for albedo correction", fixed=True
+    )
 
     _input_units_allow_dimensionless = True
 

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -13,6 +13,11 @@ def albedo(spec, energy: Quantity[u.keV], theta: Quantity[u.deg, 0, 90], anisotr
     r"""
     Add albedo correction to input spectrum
 
+    Correct input model spectrum for the component reflected by the solar atmosphere following [Kontar20006]_ using
+    precomputed green matrices from SSW.
+
+    .. [Kontar20006] https://doi.org/10.1051/0004-6361:20053672
+
     Parameters
     ----------
     spec :
@@ -32,12 +37,12 @@ def albedo(spec, energy: Quantity[u.keV], theta: Quantity[u.deg, 0, 90], anisotr
     >>> e = np.linspace(5,  500, 1000)
     >>> e_c = e[:-1] + np.diff(e)
     >>> s = 125*e_c**-3
-    >>> corrected = albedo(s, energy, theta=45*u.deg)
+    >>> corrected = albedo(s, e, theta=45*u.deg)
     """
     base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
     mu = np.cos(theta)
 
-    # what bout 0 and 1 i assume so close to 05 and 95 that it doesn't matter
+    # what about 0 and 1 assume so close to 05 and 95 that it doesn't matter
     # load precomputed green matrices
     if 0.5 <= mu <= 0.95:
         low = 5 * np.floor(mu * 20)
@@ -71,9 +76,9 @@ def albedo(spec, energy: Quantity[u.keV], theta: Quantity[u.deg, 0, 90], anisotr
     interp = RegularGridInterpolator((energy_grid_centers.to_value(u.keV), energy_grid_centers.to_value(u.keV)), albedo)
 
     de = np.diff(energy)
-    engery_centers = energy[:-1] + de / 2
+    energy_centers = energy[:-1] + de / 2
 
-    X, Y = np.meshgrid(engery_centers.to_value(u.keV), engery_centers.to_value(u.keV))
+    X, Y = np.meshgrid(energy_centers.to_value(u.keV), energy_centers.to_value(u.keV))
     albedo_interp = interp((X, Y))
 
     albedo_interp = albedo_interp * de.value / anisotropy

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -11,7 +11,7 @@ from astropy.units import Quantity
 
 from sunpy.data import cache
 
-__all__ = ["Albedo", "get_albedo_matrix"]
+__all__ = ["Albedo"]
 
 
 class Albedo(FittableModel):
@@ -84,143 +84,107 @@ class Albedo(FittableModel):
 
     _input_units_allow_dimensionless = True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, theta=u.Quantity(theta.default, theta.unit),
+                 anisotropy=anisotropy.default,
+                 **kwargs):
+
         self.energy_edges = kwargs.pop("energy_edges")
-        super().__init__(*args, **kwargs)
+
+        self._get_green_matrix(theta)
+
+        super().__init__(theta=theta,
+                         anisotropy=anisotropy,
+                         **kwargs)
 
     def evaluate(self, spectrum, theta, anisotropy):
+
         if hasattr(theta, "unit"):
-            albedo_matrix = get_albedo_matrix(self.energy_edges, theta, anisotropy)
+            theta = Quantity(theta.value,theta.unit)
         else:
-            albedo_matrix = get_albedo_matrix(self.energy_edges, theta*u.deg, anisotropy)
+            theta = theta*u.deg
+
+        if self.energy_edges[0].to_value(u.keV) < 3 or self.energy_edges[-1].to_value(u.keV) > 600:
+            raise ValueError("Supported energy range 3 <= E <= 600 keV")
+        theta = np.array(theta).squeeze() << theta.unit
+        if np.abs(theta) > 90 * u.deg:
+            raise ValueError(f"Theta must be between -90 and 90 degrees: {theta}.")
+        anisotropy = np.array(anisotropy).squeeze()
+        
+        energy_edges = tuple(self.energy_edges.to_value(u.keV))
+        theta = theta.to_value(u.deg)
+        anisotropy = anisotropy.item()
+
+        albedo_interpolator = self._get_green_matrix(theta)
+        de = np.diff(energy_edges)
+        energy_centers = energy_edges[:-1] + de / 2
+
+        X, Y = np.meshgrid(energy_centers, energy_centers)
+
+        albedo_interp = albedo_interpolator((X, Y))
+
+        # Scale by anisotropy
+        albedo_interp = (albedo_interp * de) / anisotropy  
+
+        albedo_matrix = albedo_interp.T      
+
         return spectrum + spectrum @ albedo_matrix
+    
+
+    @lru_cache
+    def _get_green_matrix(self, theta: float) -> RegularGridInterpolator:
+        r"""
+        Get greens matrix for given angle.
+
+        Interpolates pre-computed green matrices for fixed angles. The resulting greens matrix is then loaded into an
+        interpolator for later energy interpolation.
+
+        Parameters
+        ==========
+        theta : float
+            Angle between the observer and the source
+
+        Returns
+        =======
+            Greens matrix interpolator
+        """
+        mu = np.cos(theta)
+
+        base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
+        # what about 0 and 1 assume so close to 05 and 95 that it doesn't matter
+        # load precomputed green matrices
+        if 0.5 <= mu <= 0.95:
+            low = 5 * np.floor(mu * 20)
+            high = 5 * np.ceil(mu * 20)
+            low_name = f"green_compton_mu{low:03.0f}.dat"
+            high_name = f"green_compton_mu{high:03.0f}.dat"
+            low_file = cache.download(base_url + low_name)
+            high_file = cache.download(base_url + high_name)
+            green = readsav(low_file)
+            albedo_low = green["p"].albedo[0]
+            green_high = readsav(high_file)
+            albedo_high = green_high["p"].albedo[0]
+            # why 20?
+            albedo = albedo_low + (albedo_high - albedo_low) * (mu - (np.floor(mu * 20)) / 20)
+
+        elif mu < 0.5:
+            file = "green_compton_mu005.dat"
+            file = cache.download(base_url + file)
+            green = readsav(file)
+            albedo = green["p"].albedo[0]
+        elif mu > 0.95:
+            file = "green_compton_mu095.dat"
+            file = cache.download(base_url + file)
+            green = readsav(file)
+            albedo = green["p"].albedo[0]
+
+        albedo = albedo.T
+
+        # By construction in keV
+        energy_grid_edges = green["p"].edges[0]
+        energy_grid_centers = energy_grid_edges[:, 0] + (np.diff(energy_grid_edges, axis=1) / 2).reshape(-1)
+
+        return RegularGridInterpolator((energy_grid_centers, energy_grid_centers), albedo)
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"theta": u.deg}
 
-
-@lru_cache
-def _get_green_matrix(theta: float) -> RegularGridInterpolator:
-    r"""
-    Get greens matrix for given angle.
-
-    Interpolates pre-computed green matrices for fixed angles. The resulting greens matrix is then loaded into an
-    interpolator for later energy interpolation.
-
-    Parameters
-    ==========
-    theta : float
-        Angle between the observer and the source
-
-    Returns
-    =======
-        Greens matrix interpolator
-    """
-    mu = np.cos(theta)
-
-    base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
-    # what about 0 and 1 assume so close to 05 and 95 that it doesn't matter
-    # load precomputed green matrices
-    if 0.5 <= mu <= 0.95:
-        low = 5 * np.floor(mu * 20)
-        high = 5 * np.ceil(mu * 20)
-        low_name = f"green_compton_mu{low:03.0f}.dat"
-        high_name = f"green_compton_mu{high:03.0f}.dat"
-        low_file = cache.download(base_url + low_name)
-        high_file = cache.download(base_url + high_name)
-        green = readsav(low_file)
-        albedo_low = green["p"].albedo[0]
-        green_high = readsav(high_file)
-        albedo_high = green_high["p"].albedo[0]
-        # why 20?
-        albedo = albedo_low + (albedo_high - albedo_low) * (mu - (np.floor(mu * 20)) / 20)
-
-    elif mu < 0.5:
-        file = "green_compton_mu005.dat"
-        file = cache.download(base_url + file)
-        green = readsav(file)
-        albedo = green["p"].albedo[0]
-    elif mu > 0.95:
-        file = "green_compton_mu095.dat"
-        file = cache.download(base_url + file)
-        green = readsav(file)
-        albedo = green["p"].albedo[0]
-
-    albedo = albedo.T
-
-    # By construction in keV
-    energy_grid_edges = green["p"].edges[0]
-    energy_grid_centers = energy_grid_edges[:, 0] + (np.diff(energy_grid_edges, axis=1) / 2).reshape(-1)
-
-    return RegularGridInterpolator((energy_grid_centers, energy_grid_centers), albedo)
-
-
-@lru_cache
-def _calculate_albedo_matrix(energy_edges: tuple[float], theta: float, anisotropy: float) -> NDArray:
-    r"""
-    Calculate green matrix for given energies and angle.
-
-    Interpolates precomputed green matrices for given energies and angle.
-
-    Parameters
-    ==========
-    energy_edges :
-        Energy edges associated with the spectrum
-    theta :
-        Angle between the observer and the source
-    anisotropy :
-        Ratio of the flux in observer direction to the flux downwards, 1 for an isotropic source
-    """
-    albedo_interpolator = _get_green_matrix(theta)
-    de = np.diff(energy_edges)
-    energy_centers = energy_edges[:-1] + de / 2
-
-    X, Y = np.meshgrid(energy_centers, energy_centers)
-
-    albedo_interp = albedo_interpolator((X, Y))
-
-    # Scale by anisotropy
-    albedo_interp = (albedo_interp * de) / anisotropy
-
-    # Take a transpose
-    return albedo_interp.T
-
-
-@u.quantity_input
-def get_albedo_matrix(energy_edges: Quantity[u.keV], theta:Quantity[u.deg], anisotropy=1):
-    r"""
-    Get albedo correction matrix.
-
-    Matrix used to correct a photon spectrum for the component reflected by the solar atmosphere following interpolated
-    to given angle and energy indices.
-
-    Parameters
-    ----------
-    energy_edges :
-        Energy edges associated with the spectrum
-    theta :
-        Angle between Sun-observer line and X-ray source
-    anisotropy :
-        Ratio of the flux in observer direction to the flux downwards, 1 for an isotropic source
-
-    Example
-    -------
-    >>> import astropy.units as u
-    >>> import numpy as np
-    >>> from sunkit_spex.models.physical.albedo import get_albedo_matrix
-    >>> e = np.linspace(5,  500, 5)*u.keV
-    >>> albedo_matrix = get_albedo_matrix(e,theta=45*u.deg)
-    >>> albedo_matrix
-    array([[3.80274484e-01, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
-       [5.10487362e-01, 8.35309813e-07, 0.00000000e+00, 0.00000000e+00],
-       [3.61059918e-01, 2.48711099e-01, 2.50744411e-09, 0.00000000e+00],
-       [3.09323903e-01, 2.66485260e-01, 1.23563372e-01, 1.81846722e-10]])
-    """
-    if energy_edges[0].to_value(u.keV) < 3 or energy_edges[-1].to_value(u.keV) > 600:
-        raise ValueError("Supported energy range 3 <= E <= 600 keV")
-    theta = np.array(theta).squeeze() << theta.unit
-    # theta = np.array(theta)*u.deg
-    if np.abs(theta) > 90 * u.deg:
-        raise ValueError(f"Theta must be between -90 and 90 degrees: {theta}.")
-    anisotropy = np.array(anisotropy).squeeze()
-    return _calculate_albedo_matrix(tuple(energy_edges.to_value(u.keV)), theta.to_value(u.deg), anisotropy.item())

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -96,9 +96,7 @@ class Albedo(FittableModel):
 
     def evaluate(self, spectrum, theta, anisotropy):
 
-        if hasattr(theta, "unit"):
-            theta = Quantity(theta.value,theta.unit)
-        else:
+        if not isinstance(theta, Quantity)
             theta = theta*u.deg
  
         albedo_matrix = get_albedo_matrix(self.energy_edges, theta, anisotropy)

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -96,7 +96,7 @@ class Albedo(FittableModel):
 
     def evaluate(self, spectrum, theta, anisotropy):
 
-        if not isinstance(theta, Quantity)
+        if not isinstance(theta, Quantity):
             theta = theta*u.deg
  
         albedo_matrix = get_albedo_matrix(self.energy_edges, theta, anisotropy)

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -1,6 +1,8 @@
 import warnings
 import functools
 
+from functools import lru_cache
+
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 from scipy.io import readsav
@@ -128,7 +130,7 @@ def albedo(energy, theta, anisotropy=1):
     Correct input model spectrum for the component reflected by the solar atmosphere following [Kontar20006]_ using
     precomputed green matrices from SSW.
 
-    .. [Kontar20006] https://doi.org/10.1051/0004-6361:20053672
+    .. [Kontar2006] https://doi.org/10.1051/0004-6361:20053672
 
     Parameters
     ----------

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -1,0 +1,81 @@
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+from scipy.io import readsav
+
+import astropy.units as u
+from astropy.units import Quantity
+
+from sunpy.data import cache
+
+
+@u.quantity_input
+def albedo(spec, energy: Quantity[u.keV], theta: Quantity[u.deg, 0, 90], anisotropy=1):
+    r"""
+    Add albedo correction to input spectrum
+
+    Parameters
+    ----------
+    spec :
+        Input spectrum
+    energy :
+        Energy edges associated with the spectrum
+    theta :
+        Angle between Sun-observer line and X-ray source
+    anisotropy :
+        Ratio of the flux in observer direction to the flux downwards, anisotropy=1 (default) the source is isotropic
+
+    Example
+    -------
+    >>> import astropy.units as u
+    >>> import numpy as np
+    >>> from sunkit_spex.models.physical import albedo
+    >>> e = np.linspace(5,  500, 1000)
+    >>> e_c = e[:-1] + np.diff(e)
+    >>> s = 125*e_c**-3
+    >>> corrected = albedo(s, energy, theta=45*u.deg)
+    """
+    base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
+    mu = np.cos(theta)
+
+    # what bout 0 and 1 i assume so close to 05 and 95 that it doesn't matter
+    # load precomputed green matrices
+    if 0.5 <= mu <= 0.95:
+        low = 5 * np.floor(mu * 20)
+        high = 5 * np.ceil(mu * 20)
+        low_name = f"green_compton_mu{low:03.0f}.dat"
+        high_name = f"green_compton_mu{high:03.0f}.dat"
+        low_file = cache.download(base_url + low_name)
+        high_file = cache.download(base_url + high_name)
+        green = readsav(low_file)
+        albedo_low = green["p"].albedo[0]
+        green_high = readsav(high_file)
+        albedo_high = green_high["p"].albedo[0]
+        # why 20?
+        albedo = albedo_low + (albedo_high - albedo_low) * (mu - (np.floor(mu * 20)) / 20)
+
+    elif mu < 0.5:
+        file = "green_compton_mu005.dat"
+        file = cache.download(base_url + file)
+        green = readsav(file)
+        albedo = green["p"].albedo[0]
+    elif mu > 0.95:
+        file = "green_compton_mu095.dat"
+        file = cache.download(base_url + file)
+        green = readsav(file)
+        albedo = green["p"].albedo[0]
+
+    albedo = albedo.T
+    energy_grid_edges = green["p"].edges[0] * u.keV
+    energy_grid_centers = energy_grid_edges[:, 0] + (np.diff(energy_grid_edges, axis=1) / 2).reshape(-1)
+
+    interp = RegularGridInterpolator((energy_grid_centers.to_value(u.keV), energy_grid_centers.to_value(u.keV)), albedo)
+
+    de = np.diff(energy)
+    engery_centers = energy[:-1] + de / 2
+
+    X, Y = np.meshgrid(engery_centers.to_value(u.keV), engery_centers.to_value(u.keV))
+    albedo_interp = interp((X, Y))
+
+    albedo_interp = albedo_interp * de.value / anisotropy
+
+    return spec + spec @ albedo_interp.T

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -11,7 +11,7 @@ from astropy.units import Quantity
 
 from sunpy.data import cache
 
-__all__ = ["Albedo","get_albedo_matrix"]
+__all__ = ["Albedo", "get_albedo_matrix"]
 
 
 class Albedo(FittableModel):
@@ -84,28 +84,21 @@ class Albedo(FittableModel):
 
     _input_units_allow_dimensionless = True
 
-    def __init__(self, *args,
-                 **kwargs):
-
+    def __init__(self, *args, **kwargs):
         self.energy_edges = kwargs.pop("energy_edges")
 
-        super().__init__(*args,
-                         **kwargs)
-
-    
+        super().__init__(*args, **kwargs)
 
     def evaluate(self, spectrum, theta, anisotropy):
-
         if not isinstance(theta, Quantity):
-            theta = theta*u.deg
- 
+            theta = theta * u.deg
+
         albedo_matrix = get_albedo_matrix(self.energy_edges, theta, anisotropy)
 
         return spectrum + spectrum @ albedo_matrix
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"theta": u.deg}
-
 
 
 @lru_cache

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -11,7 +11,7 @@ from astropy.units import Quantity
 
 from sunpy.data import cache
 
-__all__ = ["Albedo"]
+__all__ = ["Albedo","get_albedo_matrix"]
 
 
 class Albedo(FittableModel):
@@ -84,17 +84,15 @@ class Albedo(FittableModel):
 
     _input_units_allow_dimensionless = True
 
-    def __init__(self, theta=u.Quantity(theta.default, theta.unit),
-                 anisotropy=anisotropy.default,
+    def __init__(self, *args,
                  **kwargs):
 
         self.energy_edges = kwargs.pop("energy_edges")
 
-        self._get_green_matrix(theta)
-
-        super().__init__(theta=theta,
-                         anisotropy=anisotropy,
+        super().__init__(*args,
                          **kwargs)
+
+    
 
     def evaluate(self, spectrum, theta, anisotropy):
 
@@ -102,89 +100,137 @@ class Albedo(FittableModel):
             theta = Quantity(theta.value,theta.unit)
         else:
             theta = theta*u.deg
-
-        if self.energy_edges[0].to_value(u.keV) < 3 or self.energy_edges[-1].to_value(u.keV) > 600:
-            raise ValueError("Supported energy range 3 <= E <= 600 keV")
-        theta = np.array(theta).squeeze() << theta.unit
-        if np.abs(theta) > 90 * u.deg:
-            raise ValueError(f"Theta must be between -90 and 90 degrees: {theta}.")
-        anisotropy = np.array(anisotropy).squeeze()
-        
-        energy_edges = tuple(self.energy_edges.to_value(u.keV))
-        theta = theta.to_value(u.deg)
-        anisotropy = anisotropy.item()
-
-        albedo_interpolator = self._get_green_matrix(theta)
-        de = np.diff(energy_edges)
-        energy_centers = energy_edges[:-1] + de / 2
-
-        X, Y = np.meshgrid(energy_centers, energy_centers)
-
-        albedo_interp = albedo_interpolator((X, Y))
-
-        # Scale by anisotropy
-        albedo_interp = (albedo_interp * de) / anisotropy  
-
-        albedo_matrix = albedo_interp.T      
+ 
+        albedo_matrix = get_albedo_matrix(self.energy_edges, theta, anisotropy)
 
         return spectrum + spectrum @ albedo_matrix
-    
-
-    @lru_cache
-    def _get_green_matrix(self, theta: float) -> RegularGridInterpolator:
-        r"""
-        Get greens matrix for given angle.
-
-        Interpolates pre-computed green matrices for fixed angles. The resulting greens matrix is then loaded into an
-        interpolator for later energy interpolation.
-
-        Parameters
-        ==========
-        theta : float
-            Angle between the observer and the source
-
-        Returns
-        =======
-            Greens matrix interpolator
-        """
-        mu = np.cos(theta)
-
-        base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
-        # what about 0 and 1 assume so close to 05 and 95 that it doesn't matter
-        # load precomputed green matrices
-        if 0.5 <= mu <= 0.95:
-            low = 5 * np.floor(mu * 20)
-            high = 5 * np.ceil(mu * 20)
-            low_name = f"green_compton_mu{low:03.0f}.dat"
-            high_name = f"green_compton_mu{high:03.0f}.dat"
-            low_file = cache.download(base_url + low_name)
-            high_file = cache.download(base_url + high_name)
-            green = readsav(low_file)
-            albedo_low = green["p"].albedo[0]
-            green_high = readsav(high_file)
-            albedo_high = green_high["p"].albedo[0]
-            # why 20?
-            albedo = albedo_low + (albedo_high - albedo_low) * (mu - (np.floor(mu * 20)) / 20)
-
-        elif mu < 0.5:
-            file = "green_compton_mu005.dat"
-            file = cache.download(base_url + file)
-            green = readsav(file)
-            albedo = green["p"].albedo[0]
-        elif mu > 0.95:
-            file = "green_compton_mu095.dat"
-            file = cache.download(base_url + file)
-            green = readsav(file)
-            albedo = green["p"].albedo[0]
-
-        albedo = albedo.T
-
-        # By construction in keV
-        energy_grid_edges = green["p"].edges[0]
-        energy_grid_centers = energy_grid_edges[:, 0] + (np.diff(energy_grid_edges, axis=1) / 2).reshape(-1)
-
-        return RegularGridInterpolator((energy_grid_centers, energy_grid_centers), albedo)
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"theta": u.deg}
 
+
+
+@lru_cache
+def _get_green_matrix(theta: float) -> RegularGridInterpolator:
+    r"""
+    Get greens matrix for given angle.
+
+    Interpolates pre-computed green matrices for fixed angles. The resulting greens matrix is then loaded into an
+    interpolator for later energy interpolation.
+
+    Parameters
+    ==========
+    theta : float
+        Angle between the observer and the source
+
+    Returns
+    =======
+        Greens matrix interpolator
+    """
+    mu = np.cos(theta)
+
+    base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
+    # what about 0 and 1 assume so close to 05 and 95 that it doesn't matter
+    # load precomputed green matrices
+    if 0.5 <= mu <= 0.95:
+        low = 5 * np.floor(mu * 20)
+        high = 5 * np.ceil(mu * 20)
+        low_name = f"green_compton_mu{low:03.0f}.dat"
+        high_name = f"green_compton_mu{high:03.0f}.dat"
+        low_file = cache.download(base_url + low_name)
+        high_file = cache.download(base_url + high_name)
+        green = readsav(low_file)
+        albedo_low = green["p"].albedo[0]
+        green_high = readsav(high_file)
+        albedo_high = green_high["p"].albedo[0]
+        # why 20?
+        albedo = albedo_low + (albedo_high - albedo_low) * (mu - (np.floor(mu * 20)) / 20)
+
+    elif mu < 0.5:
+        file = "green_compton_mu005.dat"
+        file = cache.download(base_url + file)
+        green = readsav(file)
+        albedo = green["p"].albedo[0]
+    elif mu > 0.95:
+        file = "green_compton_mu095.dat"
+        file = cache.download(base_url + file)
+        green = readsav(file)
+        albedo = green["p"].albedo[0]
+
+    albedo = albedo.T
+
+    # By construction in keV
+    energy_grid_edges = green["p"].edges[0]
+    energy_grid_centers = energy_grid_edges[:, 0] + (np.diff(energy_grid_edges, axis=1) / 2).reshape(-1)
+
+    return RegularGridInterpolator((energy_grid_centers, energy_grid_centers), albedo)
+
+
+@lru_cache
+def _calculate_albedo_matrix(energy_edges: tuple[float], theta: float, anisotropy: float) -> NDArray:
+    r"""
+    Calculate green matrix for given energies and angle.
+
+    Interpolates precomputed green matrices for given energies and angle.
+
+    Parameters
+    ==========
+    energy_edges :
+        Energy edges associated with the spectrum
+    theta :
+        Angle between the observer and the source
+    anisotropy :
+        Ratio of the flux in observer direction to the flux downwards, 1 for an isotropic source
+    """
+    albedo_interpolator = _get_green_matrix(theta)
+    de = np.diff(energy_edges)
+    energy_centers = energy_edges[:-1] + de / 2
+
+    X, Y = np.meshgrid(energy_centers, energy_centers)
+
+    albedo_interp = albedo_interpolator((X, Y))
+
+    # Scale by anisotropy
+    albedo_interp = (albedo_interp * de) / anisotropy
+
+    # Take a transpose
+    return albedo_interp.T
+
+
+def get_albedo_matrix(energy_edges: Quantity[u.keV], theta: Quantity[u.deg], anisotropy=1):
+    r"""
+    Get albedo correction matrix.
+
+    Matrix used to correct a photon spectrum for the component reflected by the solar atmosphere following interpolated
+    to given angle and energy indices.
+
+    Parameters
+    ----------
+    energy_edges :
+        Energy edges associated with the spectrum
+    theta :
+        Angle between Sun-observer line and X-ray source
+    anisotropy :
+        Ratio of the flux in observer direction to the flux downwards, 1 for an isotropic source
+
+    Example
+    -------
+    >>> import astropy.units as u
+    >>> import numpy as np
+    >>> from sunkit_spex.models.physical.albedo import get_albedo_matrix
+    >>> e = np.linspace(5,  500, 5)*u.keV
+    >>> albedo_matrix = get_albedo_matrix(e,theta=45*u.deg)
+    >>> albedo_matrix
+    array([[3.80274484e-01, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
+    [5.10487362e-01, 8.35309813e-07, 0.00000000e+00, 0.00000000e+00],
+    [3.61059918e-01, 2.48711099e-01, 2.50744411e-09, 0.00000000e+00],
+    [3.09323903e-01, 2.66485260e-01, 1.23563372e-01, 1.81846722e-10]])
+    """
+    if energy_edges[0].to_value(u.keV) < 3 or energy_edges[-1].to_value(u.keV) > 600:
+        raise ValueError("Supported energy range 3 <= E <= 600 keV")
+    theta = np.array(theta).squeeze() << theta.unit
+    if np.abs(theta) > 90 * u.deg:
+        raise ValueError(f"Theta must be between -90 and 90 degrees: {theta}.")
+    anisotropy = np.array(anisotropy).squeeze()
+
+    return _calculate_albedo_matrix(tuple(energy_edges.to_value(u.keV)), theta.to_value(u.deg), anisotropy.item())

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -1,47 +1,62 @@
+import warnings
+import functools
+
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 from scipy.io import readsav
 
-import astropy.units as u
-from astropy.units import Quantity
+# from astropy.units import Quantity
+from astropy.modeling import Fittable1DModel, Parameter
 
 from sunpy.data import cache
 
+__all__ = ["AlbedoModel"]
 
-@u.quantity_input
-def albedo(spec, energy: Quantity[u.keV], theta: Quantity[u.deg, 0, 90], anisotropy=1):
-    r"""
-    Add albedo correction to input spectrum
 
-    Correct input model spectrum for the component reflected by the solar atmosphere following [Kontar20006]_ using
-    precomputed green matrices from SSW.
+class AlbedoModel(Fittable1DModel):
+    def __init__(self, energy, anisotropy, theta):
+        self.energy = energy
+        self.anisotropy = Parameter(
+            default=anisotropy, description="The anisotropy used for albedo correction", fixed=True
+        )
+        self.theta = Parameter(
+            default=theta, description="Angle between the flare and the telescope in radians", fixed=True
+        )
+        super().__init__()
 
-    .. [Kontar20006] https://doi.org/10.1051/0004-6361:20053672
+    def evaluate(self, count_model):
+        """Corrects the composite count model for albedo. To be used as: ct_model = (ph_model|srm)|albedo"""
+        albedo_matrix_T = albedo(self.energy, self.theta.value, self.anisotropy.value)
 
-    Parameters
-    ----------
-    spec :
-        Input spectrum
-    energy :
-        Energy edges associated with the spectrum
-    theta :
-        Angle between Sun-observer line and X-ray source
-    anisotropy :
-        Ratio of the flux in observer direction to the flux downwards, anisotropy=1 (default) the source is isotropic
+        return count_model + count_model @ albedo_matrix_T
 
-    Example
-    -------
-    >>> import astropy.units as u
-    >>> import numpy as np
-    >>> from sunkit_spex.models.physical import albedo
-    >>> e = np.linspace(5,  500, 1000)
-    >>> e_c = e[:-1] + np.diff(e)
-    >>> s = 125*e_c**-3
-    >>> corrected = albedo(s, e, theta=45*u.deg)
-    """
-    base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
+
+# Wrapper for chaching function with numpy array args
+def np_cache(function):
+    @functools.cache
+    def cached_wrapper(*args, **kwargs):
+        args = [np.array(a) if isinstance(a, tuple) else a for a in args]
+        kwargs = {k: np.array(v) if isinstance(v, tuple) else v for k, v in kwargs.items()}
+
+        return function(*args, **kwargs)
+
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        args = [tuple(a) if isinstance(a, np.ndarray) else a for a in args]
+        kwargs = {k: tuple(v) if isinstance(v, np.ndarray) else v for k, v in kwargs.items()}
+        return cached_wrapper(*args, **kwargs)
+
+    wrapper.cache_info = cached_wrapper.cache_info
+    wrapper.cache_clear = cached_wrapper.cache_clear
+
+    return wrapper
+
+
+@functools.cache
+def load_green_matrices(theta):
     mu = np.cos(theta)
 
+    base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
     # what about 0 and 1 assume so close to 05 and 95 that it doesn't matter
     # load precomputed green matrices
     if 0.5 <= mu <= 0.95:
@@ -70,17 +85,83 @@ def albedo(spec, energy: Quantity[u.keV], theta: Quantity[u.deg, 0, 90], anisotr
         albedo = green["p"].albedo[0]
 
     albedo = albedo.T
-    energy_grid_edges = green["p"].edges[0] * u.keV
+
+    # energy_grid_edges = green["p"].edges[0] * u.keV
+    energy_grid_edges = green["p"].edges[0]
+
     energy_grid_centers = energy_grid_edges[:, 0] + (np.diff(energy_grid_edges, axis=1) / 2).reshape(-1)
 
-    interp = RegularGridInterpolator((energy_grid_centers.to_value(u.keV), energy_grid_centers.to_value(u.keV)), albedo)
+    # interp_green_matrix = RegularGridInterpolator((energy_grid_centers.to_value(u.keV), energy_grid_centers.to_value(u.keV)), albedo)
+    interp_green_matrix = RegularGridInterpolator((energy_grid_centers, energy_grid_centers), albedo)
 
+    return interp_green_matrix
+
+
+@np_cache
+def calc_albedo_matrix(energy, interp_green_matrix, anisotropy):
+    # Re-introduce units
+    # energy = energy * u.keV
     de = np.diff(energy)
     energy_centers = energy[:-1] + de / 2
 
-    X, Y = np.meshgrid(energy_centers.to_value(u.keV), energy_centers.to_value(u.keV))
-    albedo_interp = interp((X, Y))
+    # X, Y = np.meshgrid(energy_centers.to_value(u.keV), energy_centers.to_value(u.keV))
+    X, Y = np.meshgrid(energy_centers, energy_centers)
 
-    albedo_interp = albedo_interp * de.value / anisotropy
+    albedo_interp = interp_green_matrix((X, Y))
 
-    return spec + spec @ albedo_interp.T
+    # Scale by anisotropy
+    # albedo_interp = albedo_interp * de.value / anisotropy
+    albedo_interp = albedo_interp * de / anisotropy
+
+    # Take a transpose
+    albedo_interp_T = albedo_interp.T
+
+    return albedo_interp_T
+
+
+# @u.quantity_input
+# def albedo(energy: Quantity[u.keV], theta: Quantity[u.deg, 0, 90], anisotropy=1):
+def albedo(energy, theta, anisotropy=1):
+    r"""
+    Add albedo correction to input spectrum
+
+    Correct input model spectrum for the component reflected by the solar atmosphere following [Kontar20006]_ using
+    precomputed green matrices from SSW.
+
+    .. [Kontar20006] https://doi.org/10.1051/0004-6361:20053672
+
+    Parameters
+    ----------
+    spec :
+        Input count spectrum
+    energy :
+        Energy edges associated with the spectrum
+    theta :
+        Angle between Sun-observer line and X-ray source
+    anisotropy :
+        Ratio of the flux in observer direction to the flux downwards, anisotropy=1 (default) the source is isotropic
+
+    Example
+    -------
+    >>> import astropy.units as u
+    >>> import numpy as np
+    >>> from sunkit_spex.models.physical.albedo import albedo
+    >>> e = np.linspace(5,  500, 1000)
+    >>> e_c = e[:-1] + np.diff(e)
+    >>> s = 125*e_c**-3
+    >>> albedo_matrix = albedo(e, theta=0.2)
+    >>> corrected = s + s@albedo_matrix
+    """
+
+    # Add check for energy range restricted by the Green matrices
+    if energy[0] < 3 or energy[-1] > 600:
+        warnings.warn("\nCount energies are required to be >= 3keV and <=600 keV ")
+
+    # Green matrix for a given theta
+    interp_green = load_green_matrices(theta)
+
+    # Transpose of a matrix used for albedo correction, need to strip energy of units otherwise problem with caching
+    # albedo_matrix_T = calc_albedo_matrix(energy.value, interp_green, anisotropy)
+    albedo_matrix_T = calc_albedo_matrix(energy, interp_green, anisotropy)
+
+    return albedo_matrix_T

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -197,6 +197,7 @@ def _calculate_albedo_matrix(energy_edges: tuple[float], theta: float, anisotrop
     return albedo_interp.T
 
 
+@quantity_input
 def get_albedo_matrix(energy_edges: Quantity[u.keV], theta: Quantity[u.deg], anisotropy=1):
     r"""
     Get albedo correction matrix.

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -195,7 +195,7 @@ def _calculate_albedo_matrix(energy_edges: tuple[float], theta: float, anisotrop
     return albedo_interp.T
 
 
-@quantity_input
+@u.quantity_input
 def get_albedo_matrix(energy_edges: Quantity[u.keV], theta: Quantity[u.deg], anisotropy=1):
     r"""
     Get albedo correction matrix.

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -87,7 +87,7 @@ class Albedo(FittableModel):
         super().__init__(*args, **kwargs)
 
     def evaluate(self, spectrum, theta, anisotropy):
-        albedo_matrix = get_albedo_matrix(self.energy_edges, theta, anisotropy)
+        albedo_matrix = get_albedo_matrix(self.energy_edges, self.theta, anisotropy)
         return spectrum + spectrum @ albedo_matrix
 
 

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -80,7 +80,7 @@ class Albedo(FittableModel):
         description="Angle between the observer and the source",
         fixed=False,
     )
-    anisotropy = Parameter(default=1, description="The anisotropy used for albedo correction", fixed=True)
+    anisotropy = Parameter(name="anisotropy", default=1, description="The anisotropy used for albedo correction", fixed=True)
 
     _input_units_allow_dimensionless = True
 

--- a/sunkit_spex/models/physical/tests/test_albedo.py
+++ b/sunkit_spex/models/physical/tests/test_albedo.py
@@ -1,14 +1,39 @@
 import numpy as np
+import pytest
 
-from sunkit_spex.models.physical.albedo import albedo
+import astropy.units as u
+from astropy.modeling.powerlaws import PowerLaw1D
+from astropy.units import UnitsError
+
+from sunkit_spex.models.physical.albedo import Albedo, get_albedo_matrix
 
 
-def test_albedo():
-    e = np.linspace(4, 600, 597)
-    e_c = e[:-1] + np.diff(e)
-    s = 125 * e_c**-3
-    # e = e *u.keV
-    theta = 0.2  # u.rad
-    albedo_matrix = albedo(e, theta=theta)
-    out = s + s @ albedo_matrix
-    print(out)
+def test_get_albedo_matrix():
+    e = np.linspace(4, 600, 597) * u.keV
+    theta = 0 * u.deg
+    albedo_matrix = get_albedo_matrix(e, theta=theta)
+    assert albedo_matrix[0, 0] == 0.006154127884656191
+    assert albedo_matrix[298, 298] == 5.956079300274577e-24
+    assert albedo_matrix[-1, -1] == 2.3302891436400413e-27
+
+
+def test_get_albedo_matrix_bad_energy():
+    e = [1, 4, 10, 20] * u.keV
+    with pytest.raises(ValueError, match=r"Supported energy range 3.*"):
+        get_albedo_matrix(e, theta=0 * u.deg)
+
+
+def test_get_albedo_matrix_bad_angle():
+    e = [4, 10, 20] * u.keV
+    with pytest.raises(UnitsError, match=r".*Argument 'theta' to function 'get_albedo_matrix'.*'deg'."):
+        get_albedo_matrix(e, theta=91 * u.m)
+    with pytest.raises(ValueError, match=r"Theta must be between -90 and 90 degrees.*"):
+        get_albedo_matrix(e, theta=-91 * u.deg)
+
+
+def test_albedo_model():
+    e_edges = np.linspace(10, 300, 10) * u.keV
+    e_centers = e_edges[0:-1] + (0.5 * np.diff(e_edges))
+    source = PowerLaw1D(amplitude=100 * u.ph, x_0=10 * u.keV, alpha=4)
+    observed = source | Albedo(energy_edges=e_edges)
+    observed(e_centers)

--- a/sunkit_spex/models/physical/tests/test_albedo.py
+++ b/sunkit_spex/models/physical/tests/test_albedo.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-import astropy.units as u
-
 from sunkit_spex.models.physical.albedo import albedo
 
 
@@ -9,5 +7,8 @@ def test_albedo():
     e = np.linspace(4, 600, 597)
     e_c = e[:-1] + np.diff(e)
     s = 125 * e_c**-3
-    out = albedo(s, e * u.keV, 45 * u.deg)
+    # e = e *u.keV
+    theta = 0.2  # u.rad
+    albedo_matrix = albedo(e, theta=theta)
+    out = s + s @ albedo_matrix
     print(out)

--- a/sunkit_spex/models/physical/tests/test_albedo.py
+++ b/sunkit_spex/models/physical/tests/test_albedo.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+import astropy.units as u
+
+from sunkit_spex.models.physical.albedo import albedo
+
+
+def test_albedo():
+    e = np.linspace(5, 500, 250)
+    e_c = e[:-1] + np.diff(e)
+    s = 125 * e_c**-3
+    out = albedo(s, e * u.keV, 45 * u.deg)
+    print(out)

--- a/sunkit_spex/models/physical/tests/test_albedo.py
+++ b/sunkit_spex/models/physical/tests/test_albedo.py
@@ -6,7 +6,7 @@ from sunkit_spex.models.physical.albedo import albedo
 
 
 def test_albedo():
-    e = np.linspace(5, 500, 250)
+    e = np.linspace(4, 600, 597)
     e_c = e[:-1] + np.diff(e)
     s = 125 * e_c**-3
     out = albedo(s, e * u.keV, 45 * u.deg)

--- a/sunkit_spex/spectrum/spectrum.py
+++ b/sunkit_spex/spectrum/spectrum.py
@@ -11,6 +11,9 @@ from astropy.utils import lazyproperty
 __all__ = ["gwcs_from_array", "SpectralAxis", "Spectrum"]
 
 
+__doctest_requires__ = {"Spectrum": ["ndcube>=2.3"]}
+
+
 def gwcs_from_array(array):
     """
     Create a new WCS from provided tabular data. This defaults to being

--- a/sunkit_spex/spectrum/spectrum.py
+++ b/sunkit_spex/spectrum/spectrum.py
@@ -158,7 +158,7 @@ class Spectrum(NDCube):
     <sunkit_spex.spectrum.spectrum.Spectrum object at ...
     NDCube
     ------
-    Dimensions: [10.] pix
+    Shape: (10,)
     Physical Types of Axes: [('em.energy',)]
     Unit: W
     Data Type: float64


### PR DESCRIPTION
## PR Description

A a function to read in precomputed greens table and return spectrum with albedo correction, would close #128

- [x] Split function at the moment every time the function is called we would make web request and load a file from disk both very slow not ideal for fitting.   The idea would be split up into at least two parts depending on the use case/s. As far as I know often $\theta$ is fix so the loading and interpolation between $\theta$ can be cached. So one function to load the appropriate greens matrix file and interpolate for given angle. A second function would call the previous function and do the energy intepotalation (as this could change in a fit e.g. gain correction) and fold the given spectrum through obtained green matrix.
- [x] Turn in to astropy model e.g. `spec | albedo` (still waiting on proper units support in astroy for this work https://github.com/astropy/astropy/issues/17302)
- [x] Docs and tests

Recreated Fig 2 upper from the paper 

![albedo_fig](https://github.com/user-attachments/assets/ba1d65fe-fb51-471b-ac72-f3573d6caa70)
