### PR TITLE
Adds Distance and Constant multiplicative factor scaling models as Astropy models 

### DIFF
--- a/changelog/195.feature.rst
+++ b/changelog/195.feature.rst
@@ -1,6 +1,1 @@
-Add new two new Astropy model classes
-
-:py:class:`sunkit_spex.models.scaling.DistanceScale`
-:py:class:`sunkit_spex.models.scaling.Constant`
-
-These classes can be used with physical models to scale the flux either by observer distance or by a constant multiplicative factor respectively.
+Add new two new Astropy model classes, :class:`sunkit_spex.models.scaling.DistanceScale` and :class:`sunkit_spex.models.scaling.Constant`. These classes can be used with physical models to scale the flux either by observer distance or by a constant multiplicative factor respectively.

--- a/changelog/195.feature.rst
+++ b/changelog/195.feature.rst
@@ -1,7 +1,6 @@
 Add new two new Astropy model classes
 
-:py:class:`sunkit_spex.models.scaling.DistanceScale` 
+:py:class:`sunkit_spex.models.scaling.DistanceScale`
 :py:class:`sunkit_spex.models.scaling.Constant`
 
-These classes can be used with physical models to scale the flux either by observer distance or by a constant multiplicative factor respectively. 
-
+These classes can be used with physical models to scale the flux either by observer distance or by a constant multiplicative factor respectively.

--- a/changelog/195.feature.rst
+++ b/changelog/195.feature.rst
@@ -1,0 +1,7 @@
+Add new two new Astropy model classes
+
+:py:class:`sunkit_spex.models.scaling.DistanceScale` 
+:py:class:`sunkit_spex.models.scaling.Constant`
+
+These classes can be used with physical models to scale the flux either by observer distance or by a constant multiplicative factor respectively. 
+

--- a/docs/reference/models.rst
+++ b/docs/reference/models.rst
@@ -7,6 +7,7 @@ Models (`sunkit_spex.models`)
 .. automodapi:: sunkit_spex.models
 .. automodapi:: sunkit_spex.models.models
 .. automodapi:: sunkit_spex.models.instrument_response
+.. automodapi:: sunkit_spex.models.scaling
 .. automodapi:: sunkit_spex.models.physical
 .. automodapi:: sunkit_spex.models.physical.thermal
 .. automodapi:: sunkit_spex.models.physical.albedo

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -20,9 +20,9 @@ class DistanceScale(FittableModel):
     _input_units_allow_dimensionless = True
 
     def evaluate(self, spectrum, observer_distance):
-        spectrum_distance_corrected = distance_correction(spectrum, observer_distance)
 
-        return spectrum_distance_corrected
+        return distance_correction(spectrum, observer_distance)
+
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"observer_distance": u.AU}
@@ -55,6 +55,4 @@ def distance_correction(spectrum, observer_distance):
 
     scale = AU_distance_cm**2 / observer_distance_cm**2
 
-    flux = spectrum * scale
-
-    return flux
+    return spectrum * scale

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -1,0 +1,78 @@
+from functools import lru_cache
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.interpolate import RegularGridInterpolator
+from scipy.io import readsav
+
+import astropy.units as u
+from astropy.modeling import FittableModel, Parameter
+from astropy.units import Quantity
+
+from sunpy.data import cache
+
+__all__ = ["DistanceScale", "Constant"]
+
+
+class DistanceScale(FittableModel):
+
+    n_inputs = 1
+    n_outputs = 1
+    
+    observer_distance = Parameter(
+        name="observer_distance",
+        default=1,
+        unit=u.AU,
+        description="Distance to the observer in AU",
+        fixed=True,
+    )
+
+    _input_units_allow_dimensionless = True
+
+    # def __init__(self, *args, **kwargs):
+    #     self.energy_edges = kwargs.pop("energy_edges")
+
+    #     super().__init__(*args, **kwargs)
+
+    def evaluate(spectrum, observer_distance):
+
+        spectrum_distance_corrected = distance_correction(spectrum, observer_distance) 
+
+        return spectrum_distance_corrected
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return {"observer_distance": u.AU}
+
+
+
+class Constant(FittableModel):
+
+    n_inputs = 1
+    n_outputs = 1
+    
+    constant = Parameter(
+        name="constant",
+        default=1,
+        description="Multiplicative Constant",
+        fixed=True,
+    )
+
+    _input_units_allow_dimensionless = True
+
+    def evaluate(spectrum, constant):
+
+        return spectrum * constant
+
+
+
+def distance_correction(spectrum, observer_distance):
+
+    AU_distance_cm = 1*u.AU.to(u.cm)
+    observer_distance_cm = observer_distance.to(u.cm)
+
+    scale = AU_distance_cm**2 / observer_distance_cm**2
+
+    flux = spectrum * scale
+
+    return flux
+

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -29,12 +29,7 @@ class DistanceScale(FittableModel):
 
     _input_units_allow_dimensionless = True
 
-    # def __init__(self, *args, **kwargs):
-    #     self.energy_edges = kwargs.pop("energy_edges")
-
-    #     super().__init__(*args, **kwargs)
-
-    def evaluate(spectrum, observer_distance):
+    def evaluate(self, spectrum, observer_distance):
 
         spectrum_distance_corrected = distance_correction(spectrum, observer_distance) 
 
@@ -42,8 +37,6 @@ class DistanceScale(FittableModel):
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"observer_distance": u.AU}
-
-
 
 class Constant(FittableModel):
 
@@ -64,11 +57,14 @@ class Constant(FittableModel):
         return spectrum * constant
 
 
-
 def distance_correction(spectrum, observer_distance):
 
-    AU_distance_cm = 1*u.AU.to(u.cm)
-    observer_distance_cm = observer_distance.to(u.cm)
+    if isinstance(observer_distance, Quantity):
+        AU_distance_cm = 1*u.AU.to(u.cm)
+        observer_distance_cm = observer_distance.to(u.cm)
+    else:
+        AU_distance_cm = 1.496e+13
+        observer_distance_cm = observer_distance * AU_distance_cm
 
     scale = AU_distance_cm**2 / observer_distance_cm**2
 

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -20,9 +20,7 @@ class DistanceScale(FittableModel):
     _input_units_allow_dimensionless = True
 
     def evaluate(self, spectrum, observer_distance):
-
         return distance_correction(spectrum, observer_distance)
-
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"observer_distance": u.AU}

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -52,7 +52,7 @@ class Constant(FittableModel):
 
     _input_units_allow_dimensionless = True
 
-    def evaluate(spectrum, constant):
+    def evaluate(self, spectrum, constant):
 
         return spectrum * constant
 

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -4,10 +4,68 @@ import astropy.units as u
 from astropy.modeling import FittableModel, Parameter
 from astropy.units import Quantity
 
-__all__ = ["Constant", "InverseSquareFluxScaling"]
+__all__ = ["ScalarConstant", "InverseSquareFluxScaling"]
 
 
 class InverseSquareFluxScaling(FittableModel):
+    """
+    InverseSqaureFluxScaling model converts luminosity output of physical models to a distance scaled flux.
+
+    Parameters
+    ==========
+    energy_edges :
+        Energy edges associated with input spectrum
+    observer_distance:
+        Distance of the observer from the source. 
+
+    Examples
+    ========
+    .. plot::
+        :include-source:
+
+        import astropy.units as u
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        from astropy.modeling.powerlaws import PowerLaw1D
+        from astropy.visualization import quantity_support
+
+
+        from sunkit_spex.models.scaling import InverseSquareFluxScaling
+        from astropy.modeling import Parameter, FittableModel
+
+        ph_energies = np.arange(4, 100, 0.5) 
+        ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
+
+        class StraightLineModel(FittableModel):
+
+            n_inputs = 1
+            n_outputs = 1
+
+            slope = Parameter(name="slope",default=1, description="Gradient of a straight line model.")
+            intercept = Parameter(name="intercept",default=0, description="Y-intercept of a straight line model.")
+
+            _input_units_allow_dimensionless = True
+
+            @staticmethod
+            def evaluate(x, slope, intercept):
+                return  intercept*x[:-1]**slope * u.ph*u.s**-1*u.keV**-1
+            
+        sim_cont = {"slope": -2, "intercept": 100}
+
+        source = StraightLineModel(**sim_cont)
+
+        with quantity_support():
+            plt.figure()
+            for i, d in enumerate([0.25,0.5,1]):
+                distance =  InverseSquareFluxScaling(observer_distance=d*u.AU)
+                observed = source * distance    
+                plt.plot(ph_energies_centers ,  observed(ph_energies), label='D = '+str(d)+' AU')
+            plt.loglog()
+            plt.legend()
+            plt.show()
+
+    """
     n_inputs = 1
     n_outputs = 1
 
@@ -33,7 +91,63 @@ class InverseSquareFluxScaling(FittableModel):
         return {"observer_distance": u.AU}
 
 
-class Constant(FittableModel):
+class ScalarConstant(FittableModel):
+    """
+    ScalarConstant 
+    model converts luminosity output of physical models to a distance scaled flux.
+
+    Parameters
+    ==========
+    energy_edges :
+        Energy edges associated with input spectrum
+
+    Examples
+    ========
+    .. plot::
+        :include-source:
+
+        import astropy.units as u
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        from astropy.modeling.powerlaws import PowerLaw1D
+        from astropy.visualization import quantity_support
+
+        from sunkit_spex.models.scaling import ScalarConstant
+        from astropy.modeling import Parameter, FittableModel
+
+        ph_energies = np.arange(4, 100, 0.5) 
+        ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
+
+        class StraightLineModel(FittableModel):
+
+            n_inputs = 1
+            n_outputs = 1
+
+            slope = Parameter(name="slope",default=1, description="Gradient of a straight line model.")
+            intercept = Parameter(name="intercept",default=0, description="Y-intercept of a straight line model.")
+
+            _input_units_allow_dimensionless = True
+
+            @staticmethod
+            def evaluate(x, slope, intercept):
+                return  intercept*x[:-1]**slope * u.ph*u.s**-1*u.keV**-1
+            
+        sim_cont = {"slope": -2, "intercept": 100}
+
+        source = StraightLineModel(**sim_cont)
+
+        with quantity_support():
+            plt.figure()
+            for i, c in enumerate([0.25,0.5,1,2,4]):
+                constant =  ScalarConstant(constant=c*u.AU)
+                observed = source * constant    
+                plt.plot(ph_energies_centers ,  observed(ph_energies), label='Const = '+str(c))
+            plt.loglog()
+            plt.legend()
+            plt.show()
+
+    """
     n_inputs = 1
     n_outputs = 1
 

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -4,7 +4,7 @@ import astropy.units as u
 from astropy.modeling import FittableModel, Parameter
 from astropy.units import Quantity
 
-__all__ = ["ScalarConstant", "InverseSquareFluxScaling"]
+__all__ = ["InverseSquareFluxScaling", "ScalarConstant"]
 
 
 class InverseSquareFluxScaling(FittableModel):
@@ -16,7 +16,7 @@ class InverseSquareFluxScaling(FittableModel):
     energy_edges :
         Energy edges associated with input spectrum
     observer_distance:
-        Distance of the observer from the source. 
+        Distance of the observer from the source.
 
     Examples
     ========
@@ -34,7 +34,7 @@ class InverseSquareFluxScaling(FittableModel):
         from sunkit_spex.models.scaling import InverseSquareFluxScaling
         from astropy.modeling import Parameter, FittableModel
 
-        ph_energies = np.arange(4, 100, 0.5) 
+        ph_energies = np.arange(4, 100, 0.5)
         ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
 
         class StraightLineModel(FittableModel):
@@ -50,7 +50,7 @@ class InverseSquareFluxScaling(FittableModel):
             @staticmethod
             def evaluate(x, slope, intercept):
                 return  intercept*x[:-1]**slope * u.ph*u.s**-1*u.keV**-1
-            
+
         sim_cont = {"slope": -2, "intercept": 100}
 
         source = StraightLineModel(**sim_cont)
@@ -59,13 +59,14 @@ class InverseSquareFluxScaling(FittableModel):
             plt.figure()
             for i, d in enumerate([0.25,0.5,1]):
                 distance =  InverseSquareFluxScaling(observer_distance=d*u.AU)
-                observed = source * distance    
+                observed = source * distance
                 plt.plot(ph_energies_centers ,  observed(ph_energies), label='D = '+str(d)+' AU')
             plt.loglog()
             plt.legend()
             plt.show()
 
     """
+
     n_inputs = 1
     n_outputs = 1
 
@@ -93,7 +94,7 @@ class InverseSquareFluxScaling(FittableModel):
 
 class ScalarConstant(FittableModel):
     """
-    ScalarConstant 
+    ScalarConstant
     model converts luminosity output of physical models to a distance scaled flux.
 
     Parameters
@@ -116,7 +117,7 @@ class ScalarConstant(FittableModel):
         from sunkit_spex.models.scaling import ScalarConstant
         from astropy.modeling import Parameter, FittableModel
 
-        ph_energies = np.arange(4, 100, 0.5) 
+        ph_energies = np.arange(4, 100, 0.5)
         ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
 
         class StraightLineModel(FittableModel):
@@ -132,7 +133,7 @@ class ScalarConstant(FittableModel):
             @staticmethod
             def evaluate(x, slope, intercept):
                 return  intercept*x[:-1]**slope * u.ph*u.s**-1*u.keV**-1
-            
+
         sim_cont = {"slope": -2, "intercept": 100}
 
         source = StraightLineModel(**sim_cont)
@@ -141,13 +142,14 @@ class ScalarConstant(FittableModel):
             plt.figure()
             for i, c in enumerate([0.25,0.5,1,2,4]):
                 constant =  ScalarConstant(constant=c*u.AU)
-                observed = source * constant    
+                observed = source * constant
                 plt.plot(ph_energies_centers ,  observed(ph_energies), label='Const = '+str(c))
             plt.loglog()
             plt.legend()
             plt.show()
 
     """
+
     n_inputs = 1
     n_outputs = 1
 

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -1,11 +1,13 @@
+import numpy as np
+
 import astropy.units as u
 from astropy.modeling import FittableModel, Parameter
 from astropy.units import Quantity
 
-__all__ = ["Constant", "DistanceScale"]
+__all__ = ["Constant", "InverseSquareFluxScaling"]
 
 
-class DistanceScale(FittableModel):
+class InverseSquareFluxScaling(FittableModel):
     n_inputs = 1
     n_outputs = 1
 
@@ -52,12 +54,11 @@ class Constant(FittableModel):
 
 def distance_correction(spectrum, observer_distance):
     if isinstance(observer_distance, Quantity):
-        AU_distance_cm = 1 * u.AU.to(u.cm)
         observer_distance_cm = observer_distance.to(u.cm)
     else:
         AU_distance_cm = 1 * u.AU.to(u.cm).value
         observer_distance_cm = observer_distance * AU_distance_cm
 
-    scale = AU_distance_cm**2 / observer_distance_cm**2
+    scale = 4 * np.pi * (observer_distance_cm**2)
 
-    return spectrum * scale
+    return spectrum / scale

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -11,13 +11,22 @@ class DistanceScale(FittableModel):
 
     observer_distance = Parameter(
         name="observer_distance",
-        default=1,
-        unit=u.AU,
+        default=1*u.AU,
         description="Distance to the observer in AU",
         fixed=True,
     )
 
     _input_units_allow_dimensionless = True
+
+    def __init__(self,observer_distance, *args, **kwargs):
+        
+        if observer_distance.unit.is_equivalent(u.AU):
+            observer_distance = observer_distance.to(u.AU)
+        else:
+            raise ValueError('Observer distance input must be an Astropy length convertible to AU.')
+            
+        super().__init__(observer_distance, *args, **kwargs)
+
 
     def evaluate(self, spectrum, observer_distance):
         return distance_correction(spectrum, observer_distance)
@@ -48,7 +57,7 @@ def distance_correction(spectrum, observer_distance):
         AU_distance_cm = 1 * u.AU.to(u.cm)
         observer_distance_cm = observer_distance.to(u.cm)
     else:
-        AU_distance_cm = 1.496e13
+        AU_distance_cm = 1 * u.AU.to(u.cm).value
         observer_distance_cm = observer_distance * AU_distance_cm
 
     scale = AU_distance_cm**2 / observer_distance_cm**2

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -81,7 +81,6 @@ class InverseSquareFluxScaling(FittableModel):
     _input_units_allow_dimensionless = True
 
     def evaluate(self, x, observer_distance):
-        
         if isinstance(observer_distance, Quantity):
             if observer_distance.unit.is_equivalent(u.AU):
                 observer_distance_cm = observer_distance.to(u.cm)
@@ -89,7 +88,7 @@ class InverseSquareFluxScaling(FittableModel):
                 raise ValueError("Observer distance input must be an Astropy length convertible to AU.")
 
         else:
-            AU_distance_cm = 1 * u.AU.to(u.cm).value
+            AU_distance_cm = 1 * u.AU.to_value(u.cm)
             observer_distance_cm = observer_distance * AU_distance_cm
 
         correction = 1 / (4 * np.pi * (observer_distance_cm**2))
@@ -105,8 +104,7 @@ class InverseSquareFluxScaling(FittableModel):
 
 class ScalarConstant(FittableModel):
     """
-    ScalarConstant
-    model converts luminosity output of physical models to a distance scaled flux.
+    ScalarConstant model converts luminosity output of physical models to a distance scaled flux.
 
     Parameters
     ==========
@@ -167,7 +165,7 @@ class ScalarConstant(FittableModel):
     constant = Parameter(
         name="constant",
         default=1,
-        description="Multiplicative Constant",
+        description="Scalar Constant",
         fixed=True,
     )
 

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -18,37 +18,37 @@ class InverseSquareFluxScaling(FittableModel):
     observer_distance:
         Distance of the observer from the source.
 
-    Examples
-    ========
-    .. plot::
-        :include-source:
-
-        import astropy.units as u
-        import numpy as np
-        import matplotlib.pyplot as plt
-
-        from astropy.visualization import quantity_support
-
-        from sunkit_spex.models.scaling import InverseSquareFluxScaling
-        from sunkit_spex.models.models import StraightLineModel
-
-        ph_energies = np.arange(4, 100, 0.5)
-        ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
-
-        sim_cont = {"photon_model":True,"slope": -2, "intercept": 100}
-        source = StraightLineModel(**sim_cont)
-
-        with quantity_support():
-            plt.figure()
-            for i, d in enumerate([0.25,0.5,1]):
-                distance =  InverseSquareFluxScaling(observer_distance=d*u.AU)
-                observed = source * distance
-                plt.plot(ph_energies_centers ,  observed(ph_energies), label='D = '+str(d)+' AU')
-            plt.loglog()
-            plt.legend()
-            plt.show()
-
     """
+
+    # Examples
+    # ========
+    # .. plot::
+    #     :include-source:
+
+    #     import astropy.units as u
+    #     import numpy as np
+    #     import matplotlib.pyplot as plt
+
+    #     from astropy.visualization import quantity_support
+
+    #     from sunkit_spex.models.scaling import InverseSquareFluxScaling
+    #     from sunkit_spex.models.models import StraightLineModel
+
+    #     ph_energies = np.arange(4, 100, 0.5)
+    #     ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
+
+    #     sim_cont = {"photon_model":True,"slope": -2, "intercept": 100}
+    #     source = StraightLineModel(**sim_cont)
+
+    #     with quantity_support():
+    #         plt.figure()
+    #         for i, d in enumerate([0.25,0.5,1]):
+    #             distance =  InverseSquareFluxScaling(observer_distance=d*u.AU)
+    #             observed = source * distance
+    #             plt.plot(ph_energies_centers ,  observed(ph_energies), label='D = '+str(d)+' AU')
+    #         plt.loglog()
+    #         plt.legend()
+    #         plt.show()
 
     n_inputs = 1
     n_outputs = 1
@@ -96,38 +96,37 @@ class Constant(FittableModel):
         Energy edges associated with input spectrum
     constant :
         A constant value which populates the output array
-
-    Examples
-    ========
-    .. plot::
-        :include-source:
-
-        import astropy.units as u
-        import numpy as np
-        import matplotlib.pyplot as plt
-
-        from astropy.visualization import quantity_support
-
-        from sunkit_spex.models.scaling import Constant
-        from sunkit_spex.models.models import StraightLineModel
-
-        ph_energies = np.arange(4, 100, 0.5)
-        ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
-
-        sim_cont = {"photon_model":True,"slope": -2, "intercept": 100}
-        source = StraightLineModel(**sim_cont)
-
-        with quantity_support():
-            plt.figure()
-            for i, c in enumerate([0.25,0.5,1,2,4]):
-                constant =  Constant(constant=c)
-                observed = source * constant
-                plt.plot(ph_energies_centers ,  observed(ph_energies), label='Const = '+str(c))
-            plt.loglog()
-            plt.legend()
-            plt.show()
-
     """
+
+    # Examples
+    # ========
+    # .. plot::
+    #     :include-source:
+
+    #     import astropy.units as u
+    #     import numpy as np
+    #     import matplotlib.pyplot as plt
+
+    #     from astropy.visualization import quantity_support
+
+    #     from sunkit_spex.models.scaling import Constant
+    #     from sunkit_spex.models.models import StraightLineModel
+
+    #     ph_energies = np.arange(4, 100, 0.5)
+    #     ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
+
+    #     sim_cont = {"photon_model":True,"slope": -2, "intercept": 100}
+    #     source = StraightLineModel(**sim_cont)
+
+    #     with quantity_support():
+    #         plt.figure()
+    #         for i, c in enumerate([0.25,0.5,1,2,4]):
+    #             constant =  Constant(constant=c)
+    #             observed = source * constant
+    #             plt.plot(ph_energies_centers ,  observed(ph_energies), label='Const = '+str(c))
+    #         plt.loglog()
+    #         plt.legend()
+    #         plt.show()
 
     n_inputs = 1
     n_outputs = 1

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -35,7 +35,7 @@ class InverseSquareFluxScaling(FittableModel):
         ph_energies = np.arange(4, 100, 0.5)
         ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
 
-        sim_cont = {"edges":True,"slope": -2, "intercept": 100}
+        sim_cont = {"photon_model":True,"slope": -2, "intercept": 100}
         source = StraightLineModel(**sim_cont)
 
         with quantity_support():
@@ -94,6 +94,8 @@ class Constant(FittableModel):
     ==========
     energy_edges :
         Energy edges associated with input spectrum
+    constant :
+        A constant value which populates the output array
 
     Examples
     ========
@@ -112,7 +114,7 @@ class Constant(FittableModel):
         ph_energies = np.arange(4, 100, 0.5)
         ph_energies_centers = ph_energies[:-1] + 0.5*np.diff(ph_energies)
 
-        sim_cont = {"edges":True,"slope": -2, "intercept": 100}
+        sim_cont = {"photon_model":True,"slope": -2, "intercept": 100}
         source = StraightLineModel(**sim_cont)
 
         with quantity_support():

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -118,7 +118,7 @@ class Constant(FittableModel):
         with quantity_support():
             plt.figure()
             for i, c in enumerate([0.25,0.5,1,2,4]):
-                constant =  Constant(constant=c*u.AU)
+                constant =  Constant(constant=c)
                 observed = source * constant
                 plt.plot(ph_energies_centers ,  observed(ph_energies), label='Const = '+str(c))
             plt.loglog()

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -133,7 +133,7 @@ class Constant(FittableModel):
     constant = Parameter(
         name="constant",
         default=1,
-        description="Scalar Constant",
+        description="Constant",
         fixed=True,
     )
 

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -1,24 +1,14 @@
-from functools import lru_cache
-
-import numpy as np
-from numpy.typing import NDArray
-from scipy.interpolate import RegularGridInterpolator
-from scipy.io import readsav
-
 import astropy.units as u
 from astropy.modeling import FittableModel, Parameter
 from astropy.units import Quantity
 
-from sunpy.data import cache
-
-__all__ = ["DistanceScale", "Constant"]
+__all__ = ["Constant", "DistanceScale"]
 
 
 class DistanceScale(FittableModel):
-
     n_inputs = 1
     n_outputs = 1
-    
+
     observer_distance = Parameter(
         name="observer_distance",
         default=1,
@@ -30,19 +20,18 @@ class DistanceScale(FittableModel):
     _input_units_allow_dimensionless = True
 
     def evaluate(self, spectrum, observer_distance):
-
-        spectrum_distance_corrected = distance_correction(spectrum, observer_distance) 
+        spectrum_distance_corrected = distance_correction(spectrum, observer_distance)
 
         return spectrum_distance_corrected
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"observer_distance": u.AU}
 
-class Constant(FittableModel):
 
+class Constant(FittableModel):
     n_inputs = 1
     n_outputs = 1
-    
+
     constant = Parameter(
         name="constant",
         default=1,
@@ -53,17 +42,15 @@ class Constant(FittableModel):
     _input_units_allow_dimensionless = True
 
     def evaluate(self, spectrum, constant):
-
         return spectrum * constant
 
 
 def distance_correction(spectrum, observer_distance):
-
     if isinstance(observer_distance, Quantity):
-        AU_distance_cm = 1*u.AU.to(u.cm)
+        AU_distance_cm = 1 * u.AU.to(u.cm)
         observer_distance_cm = observer_distance.to(u.cm)
     else:
-        AU_distance_cm = 1.496e+13
+        AU_distance_cm = 1.496e13
         observer_distance_cm = observer_distance * AU_distance_cm
 
     scale = AU_distance_cm**2 / observer_distance_cm**2
@@ -71,4 +58,3 @@ def distance_correction(spectrum, observer_distance):
     flux = spectrum * scale
 
     return flux
-

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -11,22 +11,20 @@ class DistanceScale(FittableModel):
 
     observer_distance = Parameter(
         name="observer_distance",
-        default=1*u.AU,
+        default=1 * u.AU,
         description="Distance to the observer in AU",
         fixed=True,
     )
 
     _input_units_allow_dimensionless = True
 
-    def __init__(self,observer_distance, *args, **kwargs):
-        
+    def __init__(self, observer_distance, *args, **kwargs):
         if observer_distance.unit.is_equivalent(u.AU):
             observer_distance = observer_distance.to(u.AU)
         else:
-            raise ValueError('Observer distance input must be an Astropy length convertible to AU.')
-            
-        super().__init__(observer_distance, *args, **kwargs)
+            raise ValueError("Observer distance input must be an Astropy length convertible to AU.")
 
+        super().__init__(observer_distance, *args, **kwargs)
 
     def evaluate(self, spectrum, observer_distance):
         return distance_correction(spectrum, observer_distance)

--- a/sunkit_spex/models/tests/test_scaling.py
+++ b/sunkit_spex/models/tests/test_scaling.py
@@ -1,12 +1,9 @@
-import warnings
-
 import numpy as np
 import pytest
 
 import astropy.units as u
 
 from sunkit_spex.models import scaling
-
 
 
 def inverse_square_flux_scaling():
@@ -24,8 +21,9 @@ def inverse_square_flux_scaling():
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     observer_distance = (1 * u.AU).to(u.cm)
     inputs = energy_edges
-    expected_output = np.full(len(energy_edges)-1, 3.55581626e-28) * (1 / u.cm**2)
-    return [observer_distance,inputs], expected_output
+    expected_output = np.full(len(energy_edges) - 1, 3.55581626e-28) * (1 / u.cm**2)
+    return [observer_distance, inputs], expected_output
+
 
 def constant_scaling():
     """Define expected constant scaling values.
@@ -42,8 +40,9 @@ def constant_scaling():
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     inputs = energy_edges
     constant_value = 0.5
-    expected_output = np.full(len(energy_edges)-1, 0.5) 
-    return  [constant_value,inputs], expected_output
+    expected_output = np.full(len(energy_edges) - 1, 0.5)
+    return [constant_value, inputs], expected_output
+
 
 @pytest.mark.parametrize("distance", [inverse_square_flux_scaling])
 def test_inverse_square_flux_scaling_class_against_expected_output(distance):
@@ -51,13 +50,14 @@ def test_inverse_square_flux_scaling_class_against_expected_output(distance):
     output = scaling.InverseSquareFluxScaling(observer_distance=[input_args[0]])(input_args[1])
     np.testing.assert_allclose(output, expected, rtol=0.03)
 
+
 @pytest.mark.parametrize("constant", [constant_scaling])
 def test_constant_scaling_class_against_expected_output(constant):
     input_args, expected = constant()
     output = scaling.Constant(constant=[input_args[0]])(input_args[1])
     np.testing.assert_allclose(output, expected, rtol=0.03)
 
+
 def test_input_units_observer_distance():
     with pytest.raises(ValueError, match="Observer distance input must be an Astropy length convertible to AU."):
         scaling.InverseSquareFluxScaling(observer_distance=1 * u.keV)(np.linspace(3, 28, 100))
-

--- a/sunkit_spex/models/tests/test_scaling.py
+++ b/sunkit_spex/models/tests/test_scaling.py
@@ -54,7 +54,7 @@ def test_inverse_square_flux_scaling_class_against_expected_output(distance):
 @pytest.mark.parametrize("constant", [constant_scaling])
 def test_constant_scaling_class_against_expected_output(constant):
     input_args, expected = constant()
-    output = scaling.ScalarConstant(constant=[input_args[0]])(input_args[1])
+    output = scaling.Constant(constant=[input_args[0]])(input_args[1])
     np.testing.assert_allclose(output, expected, rtol=0.03)
 
 

--- a/sunkit_spex/models/tests/test_scaling.py
+++ b/sunkit_spex/models/tests/test_scaling.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import astropy.units as u
@@ -7,4 +8,4 @@ from sunkit_spex.models import scaling
 
 def test_input_units_observer_distance():
     with pytest.raises(ValueError, match="Observer distance input must be an Astropy length convertible to AU."):
-        scaling.InverseSquareFluxScaling(observer_distance=1 * u.keV)
+        scaling.InverseSquareFluxScaling(observer_distance=1 * u.keV)(np.linspace(3, 28, 100))

--- a/sunkit_spex/models/tests/test_scaling.py
+++ b/sunkit_spex/models/tests/test_scaling.py
@@ -1,0 +1,10 @@
+import pytest
+
+import astropy.units as u
+
+from sunkit_spex.models import scaling
+
+
+def test_input_units_observer_distance():
+    with pytest.raises(ValueError, match="Observer distance input must be an Astropy length convertible to AU."):
+        scaling.InverseSquareFluxScaling(observer_distance=1 * u.keV)

--- a/sunkit_spex/models/tests/test_scaling.py
+++ b/sunkit_spex/models/tests/test_scaling.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -6,22 +8,56 @@ import astropy.units as u
 from sunkit_spex.models import scaling
 
 
-def inverse_square_scaling():
-    """ """
+
+def inverse_square_flux_scaling():
+    """Define expected inverse square flux scaling values for a distance of 1AU.
+
+    Returns
+    -------
+    inputs: `list`
+        The Python inputs required to produce the scaling values.
+
+    expected_output: `astropy.units.Quantity`
+        The output values expected from the InverseSquareFluxScaling model class.
+
+    """
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     observer_distance = (1 * u.AU).to(u.cm)
     inputs = energy_edges
-    expected_output = np.full(len(energy_edges) - 1, 3.55581626e-28) * (1 / u.cm**2)
-    return [observer_distance, inputs], expected_output
+    expected_output = np.full(len(energy_edges)-1, 3.55581626e-28) * (1 / u.cm**2)
+    return [observer_distance,inputs], expected_output
 
+def constant_scaling():
+    """Define expected constant scaling values.
 
-@pytest.mark.parametrize("distance", [inverse_square_scaling])
-def test_continuum_emission_against_ssw(distance):
+    Returns
+    -------
+    inputs: `list`
+        The Python inputs required to produce the scaling values.
+
+    expected_output: `numpy.array`
+        The output values expected from the Constant model class.
+
+    """
+    energy_edges = np.arange(3, 28.5, 0.5) * u.keV
+    inputs = energy_edges
+    constant_value = 0.5
+    expected_output = np.full(len(energy_edges)-1, 0.5) 
+    return  [constant_value,inputs], expected_output
+
+@pytest.mark.parametrize("distance", [inverse_square_flux_scaling])
+def test_inverse_square_flux_scaling_class_against_expected_output(distance):
     input_args, expected = distance()
     output = scaling.InverseSquareFluxScaling(observer_distance=[input_args[0]])(input_args[1])
     np.testing.assert_allclose(output, expected, rtol=0.03)
 
+@pytest.mark.parametrize("constant", [constant_scaling])
+def test_constant_scaling_class_against_expected_output(constant):
+    input_args, expected = constant()
+    output = scaling.Constant(constant=[input_args[0]])(input_args[1])
+    np.testing.assert_allclose(output, expected, rtol=0.03)
 
 def test_input_units_observer_distance():
     with pytest.raises(ValueError, match="Observer distance input must be an Astropy length convertible to AU."):
         scaling.InverseSquareFluxScaling(observer_distance=1 * u.keV)(np.linspace(3, 28, 100))
+

--- a/sunkit_spex/models/tests/test_scaling.py
+++ b/sunkit_spex/models/tests/test_scaling.py
@@ -54,7 +54,7 @@ def test_inverse_square_flux_scaling_class_against_expected_output(distance):
 @pytest.mark.parametrize("constant", [constant_scaling])
 def test_constant_scaling_class_against_expected_output(constant):
     input_args, expected = constant()
-    output = scaling.Constant(constant=[input_args[0]])(input_args[1])
+    output = scaling.ScalarConstant(constant=[input_args[0]])(input_args[1])
     np.testing.assert_allclose(output, expected, rtol=0.03)
 
 

--- a/sunkit_spex/models/tests/test_scaling.py
+++ b/sunkit_spex/models/tests/test_scaling.py
@@ -6,6 +6,22 @@ import astropy.units as u
 from sunkit_spex.models import scaling
 
 
+def inverse_square_scaling():
+    """ """
+    energy_edges = np.arange(3, 28.5, 0.5) * u.keV
+    observer_distance = (1 * u.AU).to(u.cm)
+    inputs = energy_edges
+    expected_output = np.full(len(energy_edges) - 1, 3.55581626e-28) * (1 / u.cm**2)
+    return [observer_distance, inputs], expected_output
+
+
+@pytest.mark.parametrize("distance", [inverse_square_scaling])
+def test_continuum_emission_against_ssw(distance):
+    input_args, expected = distance()
+    output = scaling.InverseSquareFluxScaling(observer_distance=[input_args[0]])(input_args[1])
+    np.testing.assert_allclose(output, expected, rtol=0.03)
+
+
 def test_input_units_observer_distance():
     with pytest.raises(ValueError, match="Observer distance input must be an Astropy length convertible to AU."):
         scaling.InverseSquareFluxScaling(observer_distance=1 * u.keV)(np.linspace(3, 28, 100))


### PR DESCRIPTION
Adds an Distance and Constant multiplicative factor scaling models as Astropy models 

This PR adds `scaling.py` which includes `DistanceScale` and `Constant` which can be used alongside other models to scale for the observer distance or by an constant multiplicative factor, both the distance and the constant can be fit. 

![distance](https://github.com/user-attachments/assets/8e5709c8-48aa-4e28-877d-f4ed53318720)

![constant](https://github.com/user-attachments/assets/82f0863e-c3c6-4570-b523-f25d416797fa)


- [x] Add tests

- [x] Add doc strings 