### PR TITLE
Fixes fitting by removing `input_unit_equivalencies` from thermal classes

### DIFF
--- a/sunkit_spex/models/physical/thermal.py
+++ b/sunkit_spex/models/physical/thermal.py
@@ -157,7 +157,6 @@ class ThermalEmission(FittableModel):
 
     fe = Parameter(name="Fe", default=8.1, min=6.1, max=10.1, description="Fe relative abundance", fixed=True)
 
-    input_units_equivalencies = {"keV": u.spectral(), "K": u.temperature_energy()}
     _input_units_allow_dimensionless = True
 
     def __init__(
@@ -350,7 +349,6 @@ class ContinuumEmission(FittableModel):
 
     fe = Parameter(name="Fe", default=8.1, min=6.1, max=10.1, description="Fe relative abundance", fixed=True)
 
-    input_units_equivalencies = {"keV": u.spectral(), "K": u.temperature_energy()}
     _input_units_allow_dimensionless = True
 
     def __init__(
@@ -503,7 +501,6 @@ class LineEmission(FittableModel):
 
     fe = Parameter(name="Fe", default=8.1, min=6.1, max=10.1, description="Fe relative abundance", fixed=True)
 
-    input_units_equivalencies = {"keV": u.spectral(), "K": u.temperature_energy()}
     _input_units_allow_dimensionless = True
 
     def __init__(


### PR DESCRIPTION

## Fixes fitting by removing `input_unit_equivalencies` from thermal classes.

This is a very simple fix with only three lines changed and allows the thermal classes, `ThermalEmission`, `ContinuumEmission` and `LineEmission` to be used in compound fitting. 
