### PR TITLE
Fix bug introduced during Albedo model refactor

### DIFF
--- a/changelog/212.bugfix.rst
+++ b/changelog/212.bugfix.rst
@@ -1,0 +1,2 @@
+Fix bug introduced in refactoring of `~sunkit_spex.models.physical.albedo.Albedo` model. Internally the angle theta
+given in degrees wasn't converted to radians before use.

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -215,10 +215,10 @@ def get_albedo_matrix(energy_edges: Quantity[u.keV], theta: Quantity[u.deg], ani
     >>> e = np.linspace(5,  500, 5)*u.keV
     >>> albedo_matrix = get_albedo_matrix(e,theta=45*u.deg)
     >>> albedo_matrix
-    array([[3.80274484e-01, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
-    [5.10487362e-01, 8.35309813e-07, 0.00000000e+00, 0.00000000e+00],
-    [3.61059918e-01, 2.48711099e-01, 2.50744411e-09, 0.00000000e+00],
-    [3.09323903e-01, 2.66485260e-01, 1.23563372e-01, 1.81846722e-10]])
+    array([[7.64944936e-03, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
+           [7.17787454e-01, 1.54795970e-10, 0.00000000e+00, 0.00000000e+00],
+           [5.22059171e-01, 3.02951100e-01, 1.46291699e-13, 0.00000000e+00],
+           [4.52582540e-01, 3.69821128e-01, 1.13435321e-01, 5.95953019e-15]])
     """
     if energy_edges[0].to_value(u.keV) < 3 or energy_edges[-1].to_value(u.keV) > 600:
         raise ValueError("Supported energy range 3 <= E <= 600 keV")

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -182,7 +182,6 @@ def _calculate_albedo_matrix(energy_edges: tuple[float], theta: float, anisotrop
     X, Y = np.meshgrid(energy_centers, energy_centers)
 
     albedo_interp = albedo_interpolator((X, Y))
-    albedo_interp[albedo_interp < 1e-10] = 0
 
     # Scale by anisotropy
     albedo_interp = (albedo_interp * de) / anisotropy

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -182,7 +182,8 @@ def _calculate_albedo_matrix(energy_edges: tuple[float], theta: float, anisotrop
     X, Y = np.meshgrid(energy_centers, energy_centers)
 
     albedo_interp = albedo_interpolator((X, Y))
-
+    albedo_interp[albedo_interp<1e-10] =0
+    
     # Scale by anisotropy
     albedo_interp = (albedo_interp * de) / anisotropy
 

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -120,7 +120,7 @@ def _get_green_matrix(theta: float) -> RegularGridInterpolator:
     =======
         Greens matrix interpolator
     """
-    mu = np.cos(theta)
+    mu = np.cos(np.deg2rad(theta))
 
     base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
     # what about 0 and 1 assume so close to 05 and 95 that it doesn't matter

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -114,7 +114,7 @@ def _get_green_matrix(theta: float) -> RegularGridInterpolator:
     Parameters
     ==========
     theta : float
-        Angle between the observer and the source
+        Angle in degrees between the observer and the source
 
     Returns
     =======
@@ -136,7 +136,7 @@ def _get_green_matrix(theta: float) -> RegularGridInterpolator:
         albedo_low = green["p"].albedo[0]
         green_high = readsav(high_file)
         albedo_high = green_high["p"].albedo[0]
-        # why 20?
+        # There are 20 files from 005 to 095 in steps of 005
         albedo = albedo_low + (albedo_high - albedo_low) * (mu - (np.floor(mu * 20)) / 20)
 
     elif mu < 0.5:

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -125,7 +125,7 @@ def _get_green_matrix(theta: float) -> RegularGridInterpolator:
     base_url = "https://soho.nascom.nasa.gov/solarsoft/packages/xray/dbase/albedo/"
     # what about 0 and 1 assume so close to 05 and 95 that it doesn't matter
     # load precomputed green matrices
-    if 0.5 <= mu <= 0.95:
+    if 0.05 <= mu <= 0.95:
         low = 5 * np.floor(mu * 20)
         high = 5 * np.ceil(mu * 20)
         low_name = f"green_compton_mu{low:03.0f}.dat"
@@ -139,7 +139,7 @@ def _get_green_matrix(theta: float) -> RegularGridInterpolator:
         # There are 20 files from 005 to 095 in steps of 005
         albedo = albedo_low + (albedo_high - albedo_low) * (mu - (np.floor(mu * 20)) / 20)
 
-    elif mu < 0.5:
+    elif mu < 0.05:
         file = "green_compton_mu005.dat"
         file = cache.download(base_url + file)
         green = readsav(file)

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -182,8 +182,8 @@ def _calculate_albedo_matrix(energy_edges: tuple[float], theta: float, anisotrop
     X, Y = np.meshgrid(energy_centers, energy_centers)
 
     albedo_interp = albedo_interpolator((X, Y))
-    albedo_interp[albedo_interp<1e-10] =0
-    
+    albedo_interp[albedo_interp < 1e-10] = 0
+
     # Scale by anisotropy
     albedo_interp = (albedo_interp * de) / anisotropy
 

--- a/sunkit_spex/models/physical/tests/test_albedo.py
+++ b/sunkit_spex/models/physical/tests/test_albedo.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 import astropy.units as u
 from astropy.modeling.powerlaws import PowerLaw1D
@@ -37,3 +38,48 @@ def test_albedo_model():
     source = PowerLaw1D(amplitude=100 * u.ph, x_0=10 * u.keV, alpha=4)
     observed = source | Albedo(energy_edges=e_edges)
     observed(e_centers)
+
+
+def test_abledo_idl():
+    """
+    IDL Code to generate values used below
+
+    e_ph = dindgen(11)*2 + 10
+    ph_edges = get_edges(e_ph)
+    eye = identity(10)
+    albedo = drm_correct_albedo(theta=45.0d, ani=1.0d, drm=eye, ph=ph_edges.EDGES_2)
+    spec_in = ph_edges.mean^(-2)
+    spec_out = albedo # spec_in
+    """
+    idl_spec_in = [
+        0.0082644628099173556,
+        0.0059171597633136093,
+        0.0044444444444444444,
+        0.0034602076124567475,
+        0.0027700831024930748,
+        0.0022675736961451248,
+        0.0018903591682419660,
+        0.0016000000000000001,
+        0.0013717421124828531,
+        0.0011890606420927466,
+    ]
+    idl_spec_out = [
+        0.0095705470260438689,
+        0.0076066757846289723,
+        0.0063536931853246902,
+        0.0055135516253148236,
+        0.0045460615861343291,
+        0.0037628884235374896,
+        0.0031366857209791871,
+        0.0025179715230395604,
+        0.0019460260612382950,
+        0.0013136881009379996,
+    ]
+
+    e_ph = np.arange(11) * 2 + 10
+    albedo = Albedo(energy_edges=e_ph * u.keV, theta=45 * u.deg)
+    e_c = e_ph[:-1] + 0.5 * np.diff(e_ph)
+    spec_in = e_c**-2
+    spec_out = albedo(spec_in[:])
+    assert_allclose(idl_spec_in, spec_in)
+    assert_allclose(idl_spec_out, spec_out)

--- a/sunkit_spex/models/physical/tests/test_albedo.py
+++ b/sunkit_spex/models/physical/tests/test_albedo.py
@@ -10,7 +10,7 @@ from sunkit_spex.models.physical.albedo import Albedo, get_albedo_matrix
 
 
 def test_get_albedo_matrix():
-    e = np.linspace(4, 600, 597) * u.keV
+    e = (np.arange(597) + 4) * u.keV
     theta = 0 * u.deg
     albedo_matrix = get_albedo_matrix(e, theta=theta)
     assert albedo_matrix[0, 0] == 0.006154127884656191
@@ -40,7 +40,7 @@ def test_albedo_model():
     observed(e_centers)
 
 
-def test_abledo_idl():
+def test_albedo_idl():
     """
     IDL Code to generate values used below
 


### PR DESCRIPTION
Before the optimisation with caching the theta parameter was maintained as an angular quantity throughout. In order to use `lru_cache` some internal functions had to be changed to take python primitives (e.g float) but the code wasn't updated to account for this `np.cos(45 * u.deg)` -> `np.cos(np.deg2rad(45))`.