### PR TITLE
Fix stix loader to calculate count rate correctly

### DIFF
--- a/changelog/210.bugfix.rst
+++ b/changelog/210.bugfix.rst
@@ -1,0 +1,1 @@
+ Fixes fitting by removing input_unit_equivalencies from thermal classes, class:ThermalEmission , class:ContinuumEmission and class:LineEmission . This allows compound emission to function. 

--- a/changelog/210.bugfix.rst
+++ b/changelog/210.bugfix.rst
@@ -1,1 +1,1 @@
- Fixes fitting by removing input_unit_equivalencies from thermal classes, class:ThermalEmission , class:ContinuumEmission and class:LineEmission . This allows compound emission to function. 
+ Fixes fitting by removing input_unit_equivalencies from thermal classes, class:ThermalEmission , class:ContinuumEmission and class:LineEmission . This allows compound emission to function.

--- a/sunkit_spex/extern/stix.py
+++ b/sunkit_spex/extern/stix.py
@@ -704,7 +704,7 @@ class STIXLoader(instruments.InstrumentBlueprint):
         # self._loaded_spec_data["count_rate_error"] = counts_err/self._loaded_spec_data["effective_exposure"]/self._loaded_spec_data["count_channel_binning"]
 
         self._loaded_spec_data["count_rate"] = (
-            np.sum(
+            np.mean(
                 self._data_time_select(
                     stime=self._start_event_time, full_data=self._count_rate_perspec, etime=self._end_event_time
                 ),
@@ -723,7 +723,11 @@ class STIXLoader(instruments.InstrumentBlueprint):
                     ** 2,
                     axis=0,
                 )
-            )
+            ) / len(self._data_time_select(
+                        stime=self._start_event_time,
+                        full_data=self._count_rate_error_perspec,
+                        etime=self._end_event_time,
+                    ))
             / self._loaded_spec_data["count_channel_binning"]
         )
 

--- a/sunkit_spex/models/physical/albedo.py
+++ b/sunkit_spex/models/physical/albedo.py
@@ -84,6 +84,8 @@ class Albedo(FittableModel):
         name="anisotropy", default=1, description="The anisotropy used for albedo correction", fixed=True
     )
 
+    name = "Albedo"
+
     _input_units_allow_dimensionless = True
 
     def __init__(self, *args, **kwargs):

--- a/sunkit_spex/models/physical/tests/test_thermal.py
+++ b/sunkit_spex/models/physical/tests/test_thermal.py
@@ -50,7 +50,7 @@ def fvth_simple():
     """
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     temperature = 6 * u.MK
-    emission_measure = 1e44 / u.cm**3
+    emission_measure = 1e-5 / u.cm**3
     abundance_type = DEFAULT_ABUNDANCE_TYPE
     observer_distance = (1 * u.AU).to(u.cm)
     # fmt: off
@@ -111,7 +111,7 @@ def chianti_kev_cont_simple():
     """
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     temperature = 6 * u.MK
-    emission_measure = 1e44 / u.cm**3
+    emission_measure = 1e-5 / u.cm**3
     abundance_type = DEFAULT_ABUNDANCE_TYPE
     observer_distance = (1 * u.AU).to(u.cm)
     # fmt: off
@@ -172,7 +172,7 @@ def chianti_kev_lines_simple():
     """
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     temperature = 6 * u.MK
-    emission_measure = 1e44 / u.cm**3
+    emission_measure = 1e-5 / u.cm**3
     abundance_type = DEFAULT_ABUNDANCE_TYPE
     observer_distance = (1 * u.AU).to(u.cm)
     # fmt: off
@@ -234,7 +234,7 @@ def fvth_Fe2():
     """
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     temperature = 6 * u.MK
-    emission_measure = 1e44 / u.cm**3
+    emission_measure = 1e-5 / u.cm**3
     abundance_type = DEFAULT_ABUNDANCE_TYPE
     observer_distance = (1 * u.AU).to(u.cm)
     # fmt: off
@@ -297,7 +297,7 @@ def chianti_kev_cont_Fe2():
     """
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     temperature = 6 * u.MK
-    emission_measure = 1e44 / u.cm**3
+    emission_measure = 1e-5 / u.cm**3
     abundance_type = DEFAULT_ABUNDANCE_TYPE
     observer_distance = (1 * u.AU).to(u.cm)
     # fmt: off
@@ -360,7 +360,7 @@ def chianti_kev_lines_Fe2():
     """
     energy_edges = np.arange(3, 28.5, 0.5) * u.keV
     temperature = 6 * u.MK
-    emission_measure = 1e44 / u.cm**3
+    emission_measure = 1e-5 / u.cm**3
     abundance_type = DEFAULT_ABUNDANCE_TYPE
     observer_distance = (1 * u.AU).to(u.cm)
     # fmt: off
@@ -415,12 +415,12 @@ def test_line_emission_against_ssw(ssw):
 
 def test_scalar_energy_input():
     with pytest.raises(ValueError, match="energy_edges must be a 1-D astropy Quantity with length greater than 1"):
-        thermal.ThermalEmission(6 * u.MK, 1e44 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(10 * u.keV)
+        thermal.ThermalEmission(6 * u.MK, 1e-5 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(10 * u.keV)
 
 
 def test_len1_energy_input():
     with pytest.raises(ValueError, match="energy_edges must be a 1-D astropy Quantity with length greater than 1"):
-        thermal.ThermalEmission(6 * u.MK, 1e44 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)([10] * u.keV)
+        thermal.ThermalEmission(6 * u.MK, 1e-5 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)([10] * u.keV)
 
 
 def test_energy_out_of_range_error():
@@ -428,12 +428,12 @@ def test_energy_out_of_range_error():
         ValueError,
         match="Lower bound of the input energy must be within the range 1.0002920302956426--10.34753795157738 keV. ",
     ):
-        thermal.ThermalEmission(6 * u.MK, 1e44 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)([0.01, 10] * u.keV)
+        thermal.ThermalEmission(6 * u.MK, 1e-5 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)([0.01, 10] * u.keV)
 
 
 def test_temperature_out_of_range_error():
     with pytest.raises(ValueError, match="All input temperature values must be within the range"):
-        thermal.ThermalEmission(0.1 * u.MK, 1e44 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)([5, 10] * u.keV)
+        thermal.ThermalEmission(0.1 * u.MK, 1e-5 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)([5, 10] * u.keV)
 
 
 def test_line_energy_out_of_range_warning():
@@ -441,7 +441,7 @@ def test_line_energy_out_of_range_warning():
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
         # Trigger a warning.
-        _ = thermal.LineEmission(6 * u.MK, 1e44 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(
+        _ = thermal.LineEmission(6 * u.MK, 1e-5 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(
             np.arange(3, 1000, 0.5) * u.keV
         )
         assert issubclass(w[0].category, UserWarning)
@@ -454,14 +454,14 @@ def test_continuum_energy_out_of_range():
     ):
         # Use an energy range that goes out of bounds
         # on the lower end--should error
-        _ = thermal.ContinuumEmission(6 * u.MK, 1e44 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(
+        _ = thermal.ContinuumEmission(6 * u.MK, 1e-5 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(
             np.arange(0.1, 28, 0.5) * u.keV
         )
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         # The continuum emission should only warn if we go out of
         # bounds on the upper end.
-        _ = thermal.ContinuumEmission(6 * u.MK, 1e44 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(
+        _ = thermal.ContinuumEmission(6 * u.MK, 1e-5 / u.cm**3, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(
             np.arange(10, 1000, 0.5) * u.keV
         )
         assert issubclass(w[0].category, UserWarning)
@@ -474,7 +474,7 @@ def test_empty_flux_out_of_range():
     midpoints = energy_edges[:-1] + np.diff(energy_edges) / 2
 
     temperature = 20 << u.MK
-    em = 1e49 << u.cm**-3
+    em = 1e-5 << u.cm**-3
 
     flux = thermal.ThermalEmission(temperature, em, 8.15, 7.04, 8.1, 7.27, 6.58, 6.93, 8.1)(energy_edges)
     # the continuum is the one we need to check

--- a/sunkit_spex/models/physical/thermal.py
+++ b/sunkit_spex/models/physical/thermal.py
@@ -125,20 +125,22 @@ class ThermalEmission(FittableModel):
     n_inputs = 1
     n_outputs = 1
 
+    name = "ThermalEmission"
+
     temperature = Parameter(
         name="temperature",
-        default=1e7,
-        min=1e6,
-        max=1e8,
-        unit=u.K,
+        default=10,
+        min=1,
+        max=100,
+        unit=u.MK,
         description="Temperature of the plasma",
         fixed=False,
     )
 
     emission_measure = Parameter(
         name="emission_measure",
-        default=1e50,
-        unit=(u.cm ** (-3)),
+        default=1,
+        unit=1e49 * (u.cm ** (-3)),
         description="Emission measure of the observer",
         fixed=False,
     )
@@ -161,7 +163,7 @@ class ThermalEmission(FittableModel):
 
     def __init__(
         self,
-        temperature=u.Quantity(temperature.default, temperature.unit),
+        temperature=u.Quantity(temperature.default, temperature.unit).to(u.K),
         emission_measure=u.Quantity(emission_measure.default, emission_measure.unit),
         mg=mg.default,
         al=al.default,
@@ -317,20 +319,22 @@ class ContinuumEmission(FittableModel):
     n_inputs = 1
     n_outputs = 1
 
+    name = "ContinuumEmission"
+
     temperature = Parameter(
         name="temperature",
-        default=1e7,
-        min=1e6,
-        max=1e8,
-        unit=u.K,
+        default=10,
+        min=1,
+        max=100,
+        unit=u.MK,
         description="Temperature of the plasma",
         fixed=False,
     )
 
     emission_measure = Parameter(
         name="emission_measure",
-        default=1e50,
-        unit=(u.cm ** (-3)),
+        default=1,
+        unit=1e49 * (u.cm ** (-3)),
         description="Emission measure of the observer",
         fixed=False,
     )
@@ -353,7 +357,7 @@ class ContinuumEmission(FittableModel):
 
     def __init__(
         self,
-        temperature=u.Quantity(temperature.default, temperature.unit),
+        temperature=u.Quantity(temperature.default, temperature.unit).to(u.K),
         emission_measure=u.Quantity(emission_measure.default, emission_measure.unit),
         mg=mg.default,
         al=al.default,
@@ -469,20 +473,22 @@ class LineEmission(FittableModel):
     n_inputs = 1
     n_outputs = 1
 
+    name = "LineEmission"
+
     temperature = Parameter(
         name="temperature",
-        default=1e7,
-        min=1e6,
-        max=1e8,
-        unit=u.K,
+        default=10,
+        min=1,
+        max=100,
+        unit=u.MK,
         description="Temperature of the plasma",
         fixed=False,
     )
 
     emission_measure = Parameter(
         name="emission_measure",
-        default=1e50,
-        unit=(u.cm ** (-3)),
+        default=1,
+        unit=1e49 * (u.cm ** (-3)),
         description="Emission measure of the observer",
         fixed=False,
     )
@@ -505,7 +511,7 @@ class LineEmission(FittableModel):
 
     def __init__(
         self,
-        temperature=u.Quantity(temperature.default, temperature.unit),
+        temperature=u.Quantity(temperature.default, temperature.unit).to(u.K),
         emission_measure=u.Quantity(emission_measure.default, emission_measure.unit),
         mg=mg.default,
         al=al.default,

--- a/sunkit_spex/models/physical/thermal.py
+++ b/sunkit_spex/models/physical/thermal.py
@@ -157,7 +157,6 @@ class ThermalEmission(FittableModel):
 
     fe = Parameter(name="Fe", default=8.1, min=6.1, max=10.1, description="Fe relative abundance", fixed=True)
 
-    input_units_equivalencies = {"keV": u.spectral(), "K": u.temperature_energy()}
     _input_units_allow_dimensionless = True
 
     def __init__(
@@ -350,7 +349,6 @@ class ContinuumEmission(FittableModel):
 
     fe = Parameter(name="Fe", default=8.1, min=6.1, max=10.1, description="Fe relative abundance", fixed=True)
 
-    input_units_equivalencies = {"keV": u.spectral(), "K": u.temperature_energy()}
     _input_units_allow_dimensionless = True
 
     def __init__(
@@ -503,7 +501,6 @@ class LineEmission(FittableModel):
 
     fe = Parameter(name="Fe", default=8.1, min=6.1, max=10.1, description="Fe relative abundance", fixed=True)
 
-    input_units_equivalencies = {"keV": u.spectral(), "K": u.temperature_energy()}
     _input_units_allow_dimensionless = True
 
     def __init__(

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -149,19 +149,15 @@ class Constant(FittableModel):
 
     name = "Constant"
 
-    def __init__(self, constant=u.Quantity(constant.default, constant.unit)):
+    def __init__(self, constant=u.Quantity(constant.default)):
         super().__init__(constant=constant)
 
     def evaluate(self, x, constant):
         return constant
 
-    # @property
-    # def input_units(self):
-    #     return {self.inputs[0]: u.keV}
-
-    # @property
-    # def return_units(self, inputs_unit):
-    #     return {"y": inputs_unit["x"]}
+    @property
+    def return_units(self):
+        return {"y": self.constant.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return {"constant": self.constant.unit}
+        return {"constant": outputs_unit["y"]}

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -53,6 +53,8 @@ class InverseSquareFluxScaling(FittableModel):
         plt.show()
     """
 
+    name = "InverseSquareFluxScaling"
+
     n_inputs = 1
     n_outputs = 1
 
@@ -76,7 +78,6 @@ class InverseSquareFluxScaling(FittableModel):
         else:
             AU_distance_cm = (1 * u.AU).to_value(u.cm)
             observer_distance_cm = observer_distance * AU_distance_cm
-            print(observer_distance_cm)
 
         correction = 1 / (4 * np.pi * (observer_distance_cm**2))
         dimension = np.shape(x)[0] - 1
@@ -150,6 +151,8 @@ class Constant(FittableModel):
     )
 
     _input_units_allow_dimensionless = True
+
+    name = "Constant"
 
     def evaluate(self, x, constant):
         dimension = np.shape(x)[0] - 1

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -149,12 +149,19 @@ class Constant(FittableModel):
 
     name = "Constant"
 
+    def __init__(self, constant=u.Quantity(constant.default, constant.unit)):
+        super().__init__(constant=constant)
+
     def evaluate(self, x, constant):
         return constant
 
-    @property
-    def return_units(self, inputs_unit):
-        return {"y": inputs_unit["x"]}
+    # @property
+    # def input_units(self):
+    #     return {self.inputs[0]: u.keV}
+
+    # @property
+    # def return_units(self, inputs_unit):
+    #     return {"y": inputs_unit["x"]}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return {"constant": inputs_unit["x"]}
+        return {"constant": self.constant.unit}

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -79,12 +79,7 @@ class InverseSquareFluxScaling(FittableModel):
             AU_distance_cm = (1 * u.AU).to_value(u.cm)
             observer_distance_cm = observer_distance * AU_distance_cm
 
-        correction = 1 / (4 * np.pi * (observer_distance_cm**2))
-        dimension = np.shape(x)[0] - 1
-
-        if isinstance(observer_distance, Quantity):
-            return np.full(dimension, correction.value) * correction.unit
-        return np.full(dimension, correction)
+        return 1 / (4 * np.pi * (observer_distance_cm**2))
 
     @property
     def return_units(self):
@@ -155,11 +150,11 @@ class Constant(FittableModel):
     name = "Constant"
 
     def evaluate(self, x, constant):
-        dimension = np.shape(x)[0] - 1
+        return constant
 
-        if isinstance(constant, Quantity):
-            return np.full(dimension, constant.value) * constant.unit
-        return np.full(dimension, constant)
+    @property
+    def return_units(self, inputs_unit):
+        return {"y": inputs_unit["x"]}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"constant": inputs_unit["x"]}

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -157,7 +157,9 @@ class Constant(FittableModel):
 
     @property
     def return_units(self):
-        return {"y": self.constant.unit}
+        if isinstance(self.constant, Quantity):
+            return {"y": self.constant.unit}
+        return None
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"constant": outputs_unit["y"]}

--- a/sunkit_spex/models/scaling.py
+++ b/sunkit_spex/models/scaling.py
@@ -74,15 +74,20 @@ class InverseSquareFluxScaling(FittableModel):
                 raise ValueError("Observer distance input must be an Astropy length convertible to AU.")
 
         else:
-            AU_distance_cm = 1 * u.AU.to_value(u.cm)
+            AU_distance_cm = (1 * u.AU).to_value(u.cm)
             observer_distance_cm = observer_distance * AU_distance_cm
+            print(observer_distance_cm)
 
         correction = 1 / (4 * np.pi * (observer_distance_cm**2))
         dimension = np.shape(x)[0] - 1
 
         if isinstance(observer_distance, Quantity):
             return np.full(dimension, correction.value) * correction.unit
-        return np.full(dimension, correction) * (1 / u.cm**2)
+        return np.full(dimension, correction)
+
+    @property
+    def return_units(self):
+        return {"y": u.cm**-2}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return {"observer_distance": u.AU}


### PR DESCRIPTION

This PR changes the calculation in the STIX loader to calculate count rate correctly.


We calculate the mean rather than summed count rate for selected time range and adjust the errors accordingly.

