### PR TITLE
Calculates mean rather than summed count_rate

### DIFF
--- a/changelog/214.bugfix.rst
+++ b/changelog/214.bugfix.rst
@@ -1,1 +1,1 @@
-Fixes bug in count_rate calculation in class:`StraightLineModel`. We now calculate the mean of count rates for a given time range rather than the sum. 
+Fixes bug in count_rate calculation in class:`StraightLineModel`. We now calculate the mean of count rates for a given time range rather than the sum.

--- a/changelog/214.bugfix.rst
+++ b/changelog/214.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes bug in count_rate calculation in class:`StraightLineModel`. We now calculate the mean of count rates for a given time range rather than the sum. 

--- a/sunkit_spex/extern/stix.py
+++ b/sunkit_spex/extern/stix.py
@@ -704,7 +704,7 @@ class STIXLoader(instruments.InstrumentBlueprint):
         # self._loaded_spec_data["count_rate_error"] = counts_err/self._loaded_spec_data["effective_exposure"]/self._loaded_spec_data["count_channel_binning"]
 
         self._loaded_spec_data["count_rate"] = (
-            np.sum(
+            np.mean(
                 self._data_time_select(
                     stime=self._start_event_time, full_data=self._count_rate_perspec, etime=self._end_event_time
                 ),
@@ -723,7 +723,11 @@ class STIXLoader(instruments.InstrumentBlueprint):
                     ** 2,
                     axis=0,
                 )
-            )
+            ) / len(self._data_time_select(
+                        stime=self._start_event_time,
+                        full_data=self._count_rate_error_perspec,
+                        etime=self._end_event_time,
+                    ))
             / self._loaded_spec_data["count_channel_binning"]
         )
 


### PR DESCRIPTION

## This PR fixes a bug in `STIXLoader` that incorrectly calculates the average count rate for a given time range


Calculate mean rather than summed count rate for selected time interval and correct error calculation accordingly.

